### PR TITLE
feat: add MiniMax as LLM provider preset (default M3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ https://github.com/user-attachments/assets/a42e7457-fcc8-40da-83fc-784c45a8b95d
 - ✅ **背景音乐** - 支持添加 BGM，让视频更有氛围
 - ✅ **视觉风格** - 多种模板可选，打造独特视频风格
 - ✅ **灵活尺寸** - 支持竖屏、横屏等多种视频尺寸
-- ✅ **多种 AI 模型** - 支持 GPT、通义千问、DeepSeek、Ollama 等
+- ✅ **多种 AI 模型** - 支持 GPT、通义千问、DeepSeek、MiniMax、Ollama 等
 - ✅ **原子能力灵活组合** - 基于 ComfyUI 架构，可使用预置工作流，也可自定义任意能力（如替换生图模型为 FLUX、替换 TTS 为 ChatTTS 等）
 
 
@@ -390,7 +390,7 @@ A: 可以尝试：
 A: **本项目完全支持免费运行！**
 
 - **完全免费方案**: LLM 使用 Ollama（本地运行）+ ComfyUI 本地部署 = 0 元
-- **推荐方案**: LLM 使用通义千问（成本极低，性价比高）+ ComfyUI 本地部署
+- **推荐方案**: LLM 使用通义千问或 MiniMax（成本极低，性价比高）+ ComfyUI 本地部署
 - **云端方案**: LLM 使用 OpenAI + 图像使用 RunningHub（费用较高但无需本地环境）
 
 **选择建议**：本地有显卡建议完全免费方案，否则推荐使用通义千问（性价比高）

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ https://github.com/user-attachments/assets/a42e7457-fcc8-40da-83fc-784c45a8b95d
 - ✅ **背景音乐** - 支持添加 BGM，让视频更有氛围
 - ✅ **视觉风格** - 多种模板可选，打造独特视频风格
 - ✅ **灵活尺寸** - 支持竖屏、横屏等多种视频尺寸
-- ✅ **多种 AI 模型** - 支持 GPT、通义千问、DeepSeek、Ollama 等
+- ✅ **多种 AI 模型** - 支持 GPT、通义千问、DeepSeek、MiniMax、Ollama 等
 - ✅ **原子能力灵活组合** - 支持 ComfyUI / RunningHub 工作流，也支持直连 API 模型，可按需替换图像、视频、TTS、VLM 等能力
 
 
@@ -420,7 +420,7 @@ A: 可以尝试：
 A: **本项目完全支持免费运行！**
 
 - **完全免费方案**: LLM 使用 Ollama（本地运行）+ ComfyUI 本地部署 = 0 元
-- **推荐方案**: LLM 使用通义千问（成本极低，性价比高）+ ComfyUI 本地部署
+- **推荐方案**: LLM 使用通义千问或 MiniMax（成本极低，性价比高）+ ComfyUI 本地部署
 - **云端方案**: LLM 使用 OpenAI + 图像使用 RunningHub（费用较高但无需本地环境）
 
 **选择建议**：本地有显卡建议完全免费方案，否则推荐使用通义千问（性价比高）

--- a/README_EN.md
+++ b/README_EN.md
@@ -55,7 +55,7 @@ Just input a **topic**, and Pixelle-Video will automatically:
 - ✅ **Background Music** - Support adding BGM to make videos more atmospheric
 - ✅ **Visual Styles** - Multiple templates to choose from, create unique video styles
 - ✅ **Flexible Dimensions** - Support portrait, landscape and other video dimensions
-- ✅ **Multiple AI Models** - Support GPT, Qwen, DeepSeek, Ollama and more
+- ✅ **Multiple AI Models** - Support GPT, Qwen, DeepSeek, MiniMax, Ollama and more
 - ✅ **Flexible Atomic Capability Combination** - Based on ComfyUI architecture, can use preset workflows or customize any capability (such as replacing image generation model with FLUX, replacing TTS with ChatTTS, etc.)
 
 
@@ -386,7 +386,7 @@ A: You can try:
 A: **This project fully supports free operation!**
 
 - **Completely Free Solution**: LLM using Ollama (local) + ComfyUI local deployment = 0 cost
-- **Recommended Solution**: LLM using Qwen (extremely low cost, highly cost-effective) + ComfyUI local deployment
+- **Recommended Solution**: LLM using Qwen or MiniMax (extremely low cost, highly cost-effective) + ComfyUI local deployment
 - **Cloud Solution**: LLM using OpenAI + Image using RunningHub (higher cost but no need for local environment)
 
 **Selection Suggestion**: If you have a local GPU, recommend completely free solution, otherwise recommend using Qwen (cost-effective)

--- a/README_EN.md
+++ b/README_EN.md
@@ -57,7 +57,7 @@ Just input a **topic**, and Pixelle-Video will automatically:
 - ✅ **Background Music** - Support adding BGM to make videos more atmospheric
 - ✅ **Visual Styles** - Multiple templates to choose from, create unique video styles
 - ✅ **Flexible Dimensions** - Support portrait, landscape and other video dimensions
-- ✅ **Multiple AI Models** - Support GPT, Qwen, DeepSeek, Ollama and more
+- ✅ **Multiple AI Models** - Support GPT, Qwen, DeepSeek, MiniMax, Ollama and more
 - ✅ **Flexible Atomic Capability Combination** - Supports ComfyUI / RunningHub workflows and direct API models, allowing image, video, TTS, VLM and other capabilities to be swapped as needed
 
 
@@ -416,7 +416,7 @@ A: You can try:
 A: **This project fully supports free operation!**
 
 - **Completely Free Solution**: LLM using Ollama (local) + ComfyUI local deployment = 0 cost
-- **Recommended Solution**: LLM using Qwen (extremely low cost, highly cost-effective) + ComfyUI local deployment
+- **Recommended Solution**: LLM using Qwen or MiniMax (extremely low cost, highly cost-effective) + ComfyUI local deployment
 - **Cloud Solution**: LLM using OpenAI + Image using RunningHub (higher cost but no need for local environment)
 
 **Selection Suggestion**: If you have a local GPU, recommend completely free solution, otherwise recommend using Qwen (cost-effective)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,6 +15,7 @@ llm:
 # Qwen Max:        base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1"  model: "qwen-max"
 # OpenAI GPT-4o:   base_url: "https://api.openai.com/v1"                          model: "gpt-4o"
 # DeepSeek:        base_url: "https://api.deepseek.com"                           model: "deepseek-chat"
+# MiniMax:         base_url: "https://api.minimax.io/v1"                          model: "MiniMax-M2.7"
 # Ollama (Local):  base_url: "http://localhost:11434/v1"                          model: "llama3.2"
 
 # ==================== ComfyUI Configuration ====================

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,6 +15,7 @@ llm:
 # Qwen Max:        base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1"  model: "qwen-max"
 # OpenAI GPT-4o:   base_url: "https://api.openai.com/v1"                          model: "gpt-4o"
 # DeepSeek:        base_url: "https://api.deepseek.com"                           model: "deepseek-chat"
+# MiniMax:         base_url: "https://api.minimax.io/v1"                          model: "MiniMax-M3"
 # Ollama (Local):  base_url: "http://localhost:11434/v1"                          model: "llama3.2"
 
 # ==================== Direct API Provider Configuration ====================

--- a/pixelle_video/llm_presets.py
+++ b/pixelle_video/llm_presets.py
@@ -52,6 +52,12 @@ LLM_PRESETS: List[Dict[str, Any]] = [
         "default_api_key": "ollama",  # Required by OpenAI SDK but ignored by Ollama
     },
     {
+        "name": "MiniMax",
+        "base_url": "https://api.minimax.io/v1",
+        "model": "MiniMax-M2.7",
+        "api_key_url": "https://platform.minimaxi.com/user-center/basic-information/interface-key",
+    },
+    {
         "name": "Moonshot",
         "base_url": "https://api.moonshot.cn/v1",
         "model": "moonshot-v1-8k",

--- a/pixelle_video/llm_presets.py
+++ b/pixelle_video/llm_presets.py
@@ -52,6 +52,12 @@ LLM_PRESETS: List[Dict[str, Any]] = [
         "default_api_key": "ollama",  # Required by OpenAI SDK but ignored by Ollama
     },
     {
+        "name": "MiniMax",
+        "base_url": "https://api.minimax.io/v1",
+        "model": "MiniMax-M3",
+        "api_key_url": "https://platform.minimaxi.com/user-center/basic-information/interface-key",
+    },
+    {
         "name": "Moonshot",
         "base_url": "https://api.moonshot.cn/v1",
         "model": "moonshot-v1-8k",

--- a/pixelle_video/services/llm_service.py
+++ b/pixelle_video/services/llm_service.py
@@ -24,6 +24,9 @@ from openai import AsyncOpenAI
 from pydantic import BaseModel
 from loguru import logger
 
+# Providers that require temperature strictly > 0.0 and <= 1.0
+_STRICT_TEMPERATURE_PROVIDERS = {"api.minimax.io"}
+
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -39,6 +42,7 @@ class LLMService:
     - Alibaba Qwen (qwen-max, qwen-plus, qwen-turbo)
     - Anthropic Claude (claude-sonnet-4-5, claude-opus-4, claude-haiku-4)
     - DeepSeek (deepseek-chat)
+    - MiniMax (MiniMax-M2.7, MiniMax-M2.5) - 1M context window
     - Moonshot Kimi (moonshot-v1-8k, moonshot-v1-32k, moonshot-v1-128k)
     - Ollama (llama3.2, qwen2.5, mistral, codellama) - FREE & LOCAL!
     - Any custom provider with OpenAI-compatible API
@@ -170,6 +174,9 @@ class LLMService:
         )
         
         logger.debug(f"LLM call: model={final_model}, base_url={client.base_url}, response_type={response_type}")
+
+        # Clamp temperature for providers that require strict bounds
+        temperature = self._clamp_temperature(temperature, str(client.base_url))
         
         try:
             if response_type is not None:
@@ -281,14 +288,16 @@ You MUST respond with ONLY a valid JSON object (no markdown, no extra text)."""
     def _parse_response_as_model(self, content: str, response_type: Type[T]) -> T:
         """
         Parse LLM response content as Pydantic model
-        
+
         Args:
             content: Raw LLM response text
             response_type: Target Pydantic model class
-        
+
         Returns:
             Parsed model instance
         """
+        # Strip <think>...</think> blocks (used by some models like MiniMax M2.7)
+        content = re.sub(r'<think>[\s\S]*?</think>', '', content).strip()
         # Try direct JSON parsing first
         try:
             data = json.loads(content)
@@ -319,6 +328,18 @@ You MUST respond with ONLY a valid JSON object (no markdown, no extra text)."""
         
         raise ValueError(f"Failed to parse LLM response as {response_type.__name__}: {content[:200]}...")
     
+    @staticmethod
+    def _clamp_temperature(temperature: float, base_url: str) -> float:
+        """
+        Clamp temperature for providers with strict bounds.
+
+        Some providers (e.g. MiniMax) require temperature in (0.0, 1.0].
+        """
+        for provider_host in _STRICT_TEMPERATURE_PROVIDERS:
+            if provider_host in base_url:
+                return max(0.01, min(temperature, 1.0))
+        return temperature
+
     @property
     def active(self) -> str:
         """

--- a/pixelle_video/services/llm_service.py
+++ b/pixelle_video/services/llm_service.py
@@ -24,6 +24,9 @@ from openai import AsyncOpenAI
 from pydantic import BaseModel
 from loguru import logger
 
+# Providers that require temperature strictly > 0.0 and <= 1.0
+_STRICT_TEMPERATURE_PROVIDERS = {"api.minimax.io"}
+
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -39,6 +42,7 @@ class LLMService:
     - Alibaba Qwen (qwen-max, qwen-plus, qwen-turbo)
     - Anthropic Claude (claude-sonnet-4-5, claude-opus-4, claude-haiku-4)
     - DeepSeek (deepseek-chat)
+    - MiniMax (MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed) - 512K context, 128K max output, image input
     - Moonshot Kimi (moonshot-v1-8k, moonshot-v1-32k, moonshot-v1-128k)
     - Ollama (llama3.2, qwen2.5, mistral, codellama) - FREE & LOCAL!
     - Any custom provider with OpenAI-compatible API
@@ -170,6 +174,9 @@ class LLMService:
         )
         
         logger.debug(f"LLM call: model={final_model}, base_url={client.base_url}, response_type={response_type}")
+
+        # Clamp temperature for providers that require strict bounds
+        temperature = self._clamp_temperature(temperature, str(client.base_url))
         
         try:
             if response_type is not None:
@@ -281,14 +288,16 @@ You MUST respond with ONLY a valid JSON object (no markdown, no extra text)."""
     def _parse_response_as_model(self, content: str, response_type: Type[T]) -> T:
         """
         Parse LLM response content as Pydantic model
-        
+
         Args:
             content: Raw LLM response text
             response_type: Target Pydantic model class
-        
+
         Returns:
             Parsed model instance
         """
+        # Strip <think>...</think> blocks (used by some models like MiniMax M2.7)
+        content = re.sub(r'<think>[\s\S]*?</think>', '', content).strip()
         # Try direct JSON parsing first
         try:
             data = json.loads(content)
@@ -319,6 +328,18 @@ You MUST respond with ONLY a valid JSON object (no markdown, no extra text)."""
         
         raise ValueError(f"Failed to parse LLM response as {response_type.__name__}: {content[:200]}...")
     
+    @staticmethod
+    def _clamp_temperature(temperature: float, base_url: str) -> float:
+        """
+        Clamp temperature for providers with strict bounds.
+
+        Some providers (e.g. MiniMax) require temperature in (0.0, 1.0].
+        """
+        for provider_host in _STRICT_TEMPERATURE_PROVIDERS:
+            if provider_host in base_url:
+                return max(0.01, min(temperature, 1.0))
+        return temperature
+
     @property
     def active(self) -> str:
         """

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -1,0 +1,116 @@
+# Copyright (C) 2025 AIDC-AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""
+Integration tests for MiniMax LLM provider.
+
+These tests call the live MiniMax API and require MINIMAX_API_KEY to be set.
+Skip automatically when the key is not available.
+"""
+
+import os
+import sys
+import types
+
+# Stub out heavy dependencies
+for mod_name in (
+    "comfykit",
+    "edge_tts",
+    "edge_tts.exceptions",
+    "moviepy",
+    "moviepy.editor",
+    "html2image",
+    "streamlit",
+    "fastapi",
+    "uvicorn",
+    "beautifulsoup4",
+    "bs4",
+    "ffmpeg",
+    "PIL",
+    "PIL.Image",
+    "fastmcp",
+    "certifi",
+):
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = types.ModuleType(mod_name)
+
+sys.modules["comfykit"].ComfyKit = type("ComfyKit", (), {})
+_edge_tts_exc = types.ModuleType("edge_tts.exceptions")
+_edge_tts_exc.NoAudioReceived = type("NoAudioReceived", (Exception,), {})
+sys.modules["edge_tts.exceptions"] = _edge_tts_exc
+sys.modules["edge_tts"].exceptions = _edge_tts_exc
+sys.modules["edge_tts"].NoAudioReceived = _edge_tts_exc.NoAudioReceived
+sys.modules["edge_tts"].Communicate = type("Communicate", (), {})
+
+import pytest
+
+from pixelle_video.services.llm_service import LLMService
+
+MINIMAX_API_KEY = os.environ.get("MINIMAX_API_KEY", "")
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+MINIMAX_MODEL = "MiniMax-M2.7"
+
+skip_no_key = pytest.mark.skipif(
+    not MINIMAX_API_KEY,
+    reason="MINIMAX_API_KEY not set, skipping live integration tests",
+)
+
+
+@skip_no_key
+class TestMiniMaxIntegration:
+    """Live integration tests against MiniMax API."""
+
+    @pytest.mark.asyncio
+    async def test_llm_call_basic(self):
+        """Test a basic LLM call via MiniMax API."""
+        service = LLMService(config={})
+        result = await service(
+            prompt="Say hello in one sentence.",
+            api_key=MINIMAX_API_KEY,
+            base_url=MINIMAX_BASE_URL,
+            model=MINIMAX_MODEL,
+            temperature=0.7,
+            max_tokens=100,
+        )
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_llm_call_with_temperature_clamping(self):
+        """Test LLM call with temperature=0 (should be clamped to 0.01)."""
+        service = LLMService(config={})
+        result = await service(
+            prompt="What is 2+2? Answer with just the number.",
+            api_key=MINIMAX_API_KEY,
+            base_url=MINIMAX_BASE_URL,
+            model=MINIMAX_MODEL,
+            temperature=0.0,  # Will be clamped to 0.01
+            max_tokens=50,
+        )
+        assert isinstance(result, str)
+        assert "4" in result
+
+    @pytest.mark.asyncio
+    async def test_llm_call_structured_output(self):
+        """Test structured output with MiniMax."""
+        from pydantic import BaseModel
+
+        class SimpleAnswer(BaseModel):
+            answer: str
+
+        service = LLMService(config={})
+        result = await service(
+            prompt="What is the capital of France?",
+            api_key=MINIMAX_API_KEY,
+            base_url=MINIMAX_BASE_URL,
+            model=MINIMAX_MODEL,
+            temperature=0.5,
+            max_tokens=200,
+            response_type=SimpleAnswer,
+        )
+        assert isinstance(result, SimpleAnswer)
+        assert len(result.answer) > 0

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -1,0 +1,116 @@
+# Copyright (C) 2025 AIDC-AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""
+Integration tests for MiniMax LLM provider.
+
+These tests call the live MiniMax API and require MINIMAX_API_KEY to be set.
+Skip automatically when the key is not available.
+"""
+
+import os
+import sys
+import types
+
+# Stub out heavy dependencies
+for mod_name in (
+    "comfykit",
+    "edge_tts",
+    "edge_tts.exceptions",
+    "moviepy",
+    "moviepy.editor",
+    "html2image",
+    "streamlit",
+    "fastapi",
+    "uvicorn",
+    "beautifulsoup4",
+    "bs4",
+    "ffmpeg",
+    "PIL",
+    "PIL.Image",
+    "fastmcp",
+    "certifi",
+):
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = types.ModuleType(mod_name)
+
+sys.modules["comfykit"].ComfyKit = type("ComfyKit", (), {})
+_edge_tts_exc = types.ModuleType("edge_tts.exceptions")
+_edge_tts_exc.NoAudioReceived = type("NoAudioReceived", (Exception,), {})
+sys.modules["edge_tts.exceptions"] = _edge_tts_exc
+sys.modules["edge_tts"].exceptions = _edge_tts_exc
+sys.modules["edge_tts"].NoAudioReceived = _edge_tts_exc.NoAudioReceived
+sys.modules["edge_tts"].Communicate = type("Communicate", (), {})
+
+import pytest
+
+from pixelle_video.services.llm_service import LLMService
+
+MINIMAX_API_KEY = os.environ.get("MINIMAX_API_KEY", "")
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+MINIMAX_MODEL = "MiniMax-M3"
+
+skip_no_key = pytest.mark.skipif(
+    not MINIMAX_API_KEY,
+    reason="MINIMAX_API_KEY not set, skipping live integration tests",
+)
+
+
+@skip_no_key
+class TestMiniMaxIntegration:
+    """Live integration tests against MiniMax API."""
+
+    @pytest.mark.asyncio
+    async def test_llm_call_basic(self):
+        """Test a basic LLM call via MiniMax API."""
+        service = LLMService(config={})
+        result = await service(
+            prompt="Say hello in one sentence.",
+            api_key=MINIMAX_API_KEY,
+            base_url=MINIMAX_BASE_URL,
+            model=MINIMAX_MODEL,
+            temperature=0.7,
+            max_tokens=100,
+        )
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_llm_call_with_temperature_clamping(self):
+        """Test LLM call with temperature=0 (should be clamped to 0.01)."""
+        service = LLMService(config={})
+        result = await service(
+            prompt="What is 2+2? Answer with just the number.",
+            api_key=MINIMAX_API_KEY,
+            base_url=MINIMAX_BASE_URL,
+            model=MINIMAX_MODEL,
+            temperature=0.0,  # Will be clamped to 0.01
+            max_tokens=50,
+        )
+        assert isinstance(result, str)
+        assert "4" in result
+
+    @pytest.mark.asyncio
+    async def test_llm_call_structured_output(self):
+        """Test structured output with MiniMax."""
+        from pydantic import BaseModel
+
+        class SimpleAnswer(BaseModel):
+            answer: str
+
+        service = LLMService(config={})
+        result = await service(
+            prompt="What is the capital of France?",
+            api_key=MINIMAX_API_KEY,
+            base_url=MINIMAX_BASE_URL,
+            model=MINIMAX_MODEL,
+            temperature=0.5,
+            max_tokens=200,
+            response_type=SimpleAnswer,
+        )
+        assert isinstance(result, SimpleAnswer)
+        assert len(result.answer) > 0

--- a/tests/test_minimax_unit.py
+++ b/tests/test_minimax_unit.py
@@ -1,0 +1,337 @@
+# Copyright (C) 2025 AIDC-AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Unit tests for MiniMax LLM provider integration.
+
+These tests use direct module imports to avoid heavy dependency requirements.
+"""
+
+import sys
+import types
+import pytest
+
+# Stub out heavy dependencies so we can import the modules under test
+# without needing comfykit, edge_tts, etc. installed.
+for mod_name in (
+    "comfykit",
+    "edge_tts",
+    "edge_tts.exceptions",
+    "moviepy",
+    "moviepy.editor",
+    "html2image",
+    "streamlit",
+    "fastapi",
+    "uvicorn",
+    "beautifulsoup4",
+    "bs4",
+    "ffmpeg",
+    "PIL",
+    "PIL.Image",
+    "fastmcp",
+    "certifi",
+):
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = types.ModuleType(mod_name)
+
+# Patch comfykit.ComfyKit for service.py
+sys.modules["comfykit"].ComfyKit = type("ComfyKit", (), {})
+
+# Patch edge_tts exceptions module
+_edge_tts_exc = types.ModuleType("edge_tts.exceptions")
+_edge_tts_exc.NoAudioReceived = type("NoAudioReceived", (Exception,), {})
+sys.modules["edge_tts.exceptions"] = _edge_tts_exc
+# Also set exceptions attribute on the edge_tts stub module
+sys.modules["edge_tts"].exceptions = _edge_tts_exc
+sys.modules["edge_tts"].NoAudioReceived = _edge_tts_exc.NoAudioReceived
+# edge_tts also uses Communicate
+sys.modules["edge_tts"].Communicate = type("Communicate", (), {})
+
+
+# ============================================================
+# LLM Presets - MiniMax entry
+# ============================================================
+
+
+class TestMiniMaxPreset:
+    """Test MiniMax preset configuration."""
+
+    def _get_presets_module(self):
+        from pixelle_video.llm_presets import (
+            LLM_PRESETS,
+            get_preset,
+            get_preset_names,
+            find_preset_by_base_url_and_model,
+        )
+        return LLM_PRESETS, get_preset, get_preset_names, find_preset_by_base_url_and_model
+
+    def test_minimax_in_presets(self):
+        """MiniMax should be registered in the LLM_PRESETS list."""
+        _, _, get_preset_names, _ = self._get_presets_module()
+        names = get_preset_names()
+        assert "MiniMax" in names
+
+    def test_minimax_preset_fields(self):
+        """MiniMax preset should have all required fields."""
+        _, get_preset, _, _ = self._get_presets_module()
+        preset = get_preset("MiniMax")
+        assert preset, "MiniMax preset not found"
+        assert preset["name"] == "MiniMax"
+        assert preset["base_url"] == "https://api.minimax.io/v1"
+        assert preset["model"] == "MiniMax-M2.7"
+        assert "api_key_url" in preset
+        assert preset["api_key_url"].startswith("https://")
+
+    def test_minimax_preset_lookup_by_url_and_model(self):
+        """find_preset_by_base_url_and_model should match MiniMax."""
+        _, _, _, find_preset = self._get_presets_module()
+        name = find_preset("https://api.minimax.io/v1", "MiniMax-M2.7")
+        assert name == "MiniMax"
+
+    def test_minimax_preset_lookup_wrong_model(self):
+        """Mismatched model should not match MiniMax preset."""
+        _, _, _, find_preset = self._get_presets_module()
+        name = find_preset("https://api.minimax.io/v1", "wrong-model")
+        assert name is None
+
+    def test_minimax_no_default_api_key(self):
+        """MiniMax preset should NOT have a default_api_key (requires real key)."""
+        _, get_preset, _, _ = self._get_presets_module()
+        preset = get_preset("MiniMax")
+        assert "default_api_key" not in preset
+
+    def test_preset_count_includes_minimax(self):
+        """Total preset count should include MiniMax."""
+        presets, _, _, _ = self._get_presets_module()
+        # At minimum: Qwen, OpenAI, Claude, DeepSeek, Ollama, MiniMax, Moonshot
+        assert len(presets) >= 7
+
+    def test_all_presets_have_required_keys(self):
+        """Every preset (including MiniMax) must have name, base_url, model, api_key_url."""
+        presets, _, _, _ = self._get_presets_module()
+        for preset in presets:
+            assert "name" in preset, f"preset missing 'name': {preset}"
+            assert "base_url" in preset, f"preset {preset['name']} missing 'base_url'"
+            assert "model" in preset, f"preset {preset['name']} missing 'model'"
+            assert "api_key_url" in preset, f"preset {preset['name']} missing 'api_key_url'"
+
+
+# ============================================================
+# Temperature clamping
+# ============================================================
+
+
+class TestTemperatureClamping:
+    """Test temperature clamping for MiniMax provider."""
+
+    def _get_service_module(self):
+        from pixelle_video.services.llm_service import LLMService, _STRICT_TEMPERATURE_PROVIDERS
+        return LLMService, _STRICT_TEMPERATURE_PROVIDERS
+
+    def test_minimax_host_in_strict_providers(self):
+        """api.minimax.io should be in the strict temperature provider set."""
+        _, providers = self._get_service_module()
+        assert "api.minimax.io" in providers
+
+    def test_clamp_zero_temperature(self):
+        """Temperature 0.0 should be clamped to 0.01 for MiniMax."""
+        LLMService, _ = self._get_service_module()
+        result = LLMService._clamp_temperature(0.0, "https://api.minimax.io/v1")
+        assert result == 0.01
+
+    def test_clamp_negative_temperature(self):
+        """Negative temperature should be clamped to 0.01 for MiniMax."""
+        LLMService, _ = self._get_service_module()
+        result = LLMService._clamp_temperature(-1.0, "https://api.minimax.io/v1")
+        assert result == 0.01
+
+    def test_clamp_high_temperature(self):
+        """Temperature above 1.0 should be clamped to 1.0 for MiniMax."""
+        LLMService, _ = self._get_service_module()
+        result = LLMService._clamp_temperature(1.5, "https://api.minimax.io/v1")
+        assert result == 1.0
+
+    def test_clamp_normal_temperature(self):
+        """Valid temperature should pass through unchanged for MiniMax."""
+        LLMService, _ = self._get_service_module()
+        result = LLMService._clamp_temperature(0.7, "https://api.minimax.io/v1")
+        assert result == 0.7
+
+    def test_clamp_boundary_temperature_one(self):
+        """Temperature 1.0 is valid and should not change for MiniMax."""
+        LLMService, _ = self._get_service_module()
+        result = LLMService._clamp_temperature(1.0, "https://api.minimax.io/v1")
+        assert result == 1.0
+
+    def test_no_clamp_for_openai(self):
+        """Temperature should NOT be clamped for OpenAI provider."""
+        LLMService, _ = self._get_service_module()
+        result = LLMService._clamp_temperature(0.0, "https://api.openai.com/v1")
+        assert result == 0.0
+
+    def test_no_clamp_for_generic_provider(self):
+        """Temperature should NOT be clamped for unknown providers."""
+        LLMService, _ = self._get_service_module()
+        result = LLMService._clamp_temperature(2.0, "https://custom-api.example.com/v1")
+        assert result == 2.0
+
+    def test_clamp_very_small_positive(self):
+        """Very small positive temperature should pass for MiniMax."""
+        LLMService, _ = self._get_service_module()
+        result = LLMService._clamp_temperature(0.05, "https://api.minimax.io/v1")
+        assert result == 0.05
+
+
+# ============================================================
+# LLMService.__call__ integration with clamping
+# ============================================================
+
+
+class TestLLMServiceCallWithMiniMax:
+    """Test LLMService.__call__ applies temperature clamping for MiniMax."""
+
+    def _make_service(self):
+        from pixelle_video.services.llm_service import LLMService
+        return LLMService(config={})
+
+    @pytest.mark.asyncio
+    async def test_call_applies_temperature_clamping(self):
+        """When using MiniMax base_url, temperature should be clamped in the API call."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+        from pixelle_video.services.llm_service import LLMService
+
+        service = self._make_service()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Hello from MiniMax"
+
+        with patch.object(service, "_create_client") as mock_create:
+            mock_client = AsyncMock()
+            mock_client.base_url = "https://api.minimax.io/v1"
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+            mock_create.return_value = mock_client
+
+            with patch.object(service, "_get_config_value", return_value="MiniMax-M2.7"):
+                result = await service(
+                    prompt="Hello",
+                    base_url="https://api.minimax.io/v1",
+                    temperature=0.0,
+                )
+
+            assert result == "Hello from MiniMax"
+            call_kwargs = mock_client.chat.completions.create.call_args
+            assert call_kwargs.kwargs["temperature"] == 0.01
+
+    @pytest.mark.asyncio
+    async def test_call_no_clamp_for_openai(self):
+        """When using OpenAI base_url, temperature should NOT be clamped."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        service = self._make_service()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Hello from OpenAI"
+
+        with patch.object(service, "_create_client") as mock_create:
+            mock_client = AsyncMock()
+            mock_client.base_url = "https://api.openai.com/v1"
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+            mock_create.return_value = mock_client
+
+            with patch.object(service, "_get_config_value", return_value="gpt-4o"):
+                result = await service(
+                    prompt="Hello",
+                    base_url="https://api.openai.com/v1",
+                    temperature=0.0,
+                )
+
+            assert result == "Hello from OpenAI"
+            call_kwargs = mock_client.chat.completions.create.call_args
+            assert call_kwargs.kwargs["temperature"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_call_structured_output_with_minimax(self):
+        """Structured output should also clamp temperature for MiniMax."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+        from pydantic import BaseModel
+
+        class TestOutput(BaseModel):
+            text: str
+
+        service = self._make_service()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = '{"text": "hello"}'
+
+        with patch.object(service, "_create_client") as mock_create:
+            mock_client = AsyncMock()
+            mock_client.base_url = "https://api.minimax.io/v1"
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+            mock_create.return_value = mock_client
+
+            with patch.object(service, "_get_config_value", return_value="MiniMax-M2.7"):
+                result = await service(
+                    prompt="Generate output",
+                    base_url="https://api.minimax.io/v1",
+                    temperature=0.0,
+                    response_type=TestOutput,
+                )
+
+            assert isinstance(result, TestOutput)
+            assert result.text == "hello"
+
+
+# ============================================================
+# LLM Utility - connection test with MiniMax URL
+# ============================================================
+
+
+class TestLLMUtilWithMiniMax:
+    """Test llm_util functions with MiniMax endpoint."""
+
+    def test_fetch_models_minimax_url(self):
+        """fetch_available_models should build correct URL for MiniMax."""
+        from unittest.mock import MagicMock, patch
+        from pixelle_video.utils.llm_util import fetch_available_models
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {"id": "MiniMax-M2.7"},
+                {"id": "MiniMax-M2.5"},
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response
+
+        with patch("pixelle_video.utils.llm_util.httpx.Client", return_value=mock_client):
+            models = fetch_available_models("test-key", "https://api.minimax.io/v1")
+
+        assert "MiniMax-M2.7" in models
+        assert "MiniMax-M2.5" in models
+        call_url = mock_client.get.call_args[0][0]
+        assert call_url == "https://api.minimax.io/v1/models"
+
+    def test_connection_test_minimax(self):
+        """test_llm_connection should work with MiniMax endpoint."""
+        from unittest.mock import patch
+        from pixelle_video.utils.llm_util import test_llm_connection
+
+        with patch(
+            "pixelle_video.utils.llm_util.fetch_available_models",
+            return_value=["MiniMax-M2.7", "MiniMax-M2.5"],
+        ):
+            success, message, count = test_llm_connection(
+                "test-key", "https://api.minimax.io/v1"
+            )
+
+        assert success is True
+        assert count == 2
+        assert "2" in message

--- a/tests/test_minimax_unit.py
+++ b/tests/test_minimax_unit.py
@@ -1,0 +1,337 @@
+# Copyright (C) 2025 AIDC-AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Unit tests for MiniMax LLM provider integration.
+
+These tests use direct module imports to avoid heavy dependency requirements.
+"""
+
+import sys
+import types
+import pytest
+
+# Stub out heavy dependencies so we can import the modules under test
+# without needing comfykit, edge_tts, etc. installed.
+for mod_name in (
+    "comfykit",
+    "edge_tts",
+    "edge_tts.exceptions",
+    "moviepy",
+    "moviepy.editor",
+    "html2image",
+    "streamlit",
+    "fastapi",
+    "uvicorn",
+    "beautifulsoup4",
+    "bs4",
+    "ffmpeg",
+    "PIL",
+    "PIL.Image",
+    "fastmcp",
+    "certifi",
+):
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = types.ModuleType(mod_name)
+
+# Patch comfykit.ComfyKit for service.py
+sys.modules["comfykit"].ComfyKit = type("ComfyKit", (), {})
+
+# Patch edge_tts exceptions module
+_edge_tts_exc = types.ModuleType("edge_tts.exceptions")
+_edge_tts_exc.NoAudioReceived = type("NoAudioReceived", (Exception,), {})
+sys.modules["edge_tts.exceptions"] = _edge_tts_exc
+# Also set exceptions attribute on the edge_tts stub module
+sys.modules["edge_tts"].exceptions = _edge_tts_exc
+sys.modules["edge_tts"].NoAudioReceived = _edge_tts_exc.NoAudioReceived
+# edge_tts also uses Communicate
+sys.modules["edge_tts"].Communicate = type("Communicate", (), {})
+
+
+# ============================================================
+# LLM Presets - MiniMax entry
+# ============================================================
+
+
+class TestMiniMaxPreset:
+    """Test MiniMax preset configuration."""
+
+    def _get_presets_module(self):
+        from pixelle_video.llm_presets import (
+            LLM_PRESETS,
+            get_preset,
+            get_preset_names,
+            find_preset_by_base_url_and_model,
+        )
+        return LLM_PRESETS, get_preset, get_preset_names, find_preset_by_base_url_and_model
+
+    def test_minimax_in_presets(self):
+        """MiniMax should be registered in the LLM_PRESETS list."""
+        _, _, get_preset_names, _ = self._get_presets_module()
+        names = get_preset_names()
+        assert "MiniMax" in names
+
+    def test_minimax_preset_fields(self):
+        """MiniMax preset should have all required fields."""
+        _, get_preset, _, _ = self._get_presets_module()
+        preset = get_preset("MiniMax")
+        assert preset, "MiniMax preset not found"
+        assert preset["name"] == "MiniMax"
+        assert preset["base_url"] == "https://api.minimax.io/v1"
+        assert preset["model"] == "MiniMax-M3"
+        assert "api_key_url" in preset
+        assert preset["api_key_url"].startswith("https://")
+
+    def test_minimax_preset_lookup_by_url_and_model(self):
+        """find_preset_by_base_url_and_model should match MiniMax."""
+        _, _, _, find_preset = self._get_presets_module()
+        name = find_preset("https://api.minimax.io/v1", "MiniMax-M3")
+        assert name == "MiniMax"
+
+    def test_minimax_preset_lookup_wrong_model(self):
+        """Mismatched model should not match MiniMax preset."""
+        _, _, _, find_preset = self._get_presets_module()
+        name = find_preset("https://api.minimax.io/v1", "wrong-model")
+        assert name is None
+
+    def test_minimax_no_default_api_key(self):
+        """MiniMax preset should NOT have a default_api_key (requires real key)."""
+        _, get_preset, _, _ = self._get_presets_module()
+        preset = get_preset("MiniMax")
+        assert "default_api_key" not in preset
+
+    def test_preset_count_includes_minimax(self):
+        """Total preset count should include MiniMax."""
+        presets, _, _, _ = self._get_presets_module()
+        # At minimum: Qwen, OpenAI, Claude, DeepSeek, Ollama, MiniMax, Moonshot
+        assert len(presets) >= 7
+
+    def test_all_presets_have_required_keys(self):
+        """Every preset (including MiniMax) must have name, base_url, model, api_key_url."""
+        presets, _, _, _ = self._get_presets_module()
+        for preset in presets:
+            assert "name" in preset, f"preset missing 'name': {preset}"
+            assert "base_url" in preset, f"preset {preset['name']} missing 'base_url'"
+            assert "model" in preset, f"preset {preset['name']} missing 'model'"
+            assert "api_key_url" in preset, f"preset {preset['name']} missing 'api_key_url'"
+
+
+# ============================================================
+# Temperature clamping
+# ============================================================
+
+
+class TestTemperatureClamping:
+    """Test temperature clamping for MiniMax provider."""
+
+    def _get_service_module(self):
+        from pixelle_video.services.llm_service import LLMService, _STRICT_TEMPERATURE_PROVIDERS
+        return LLMService, _STRICT_TEMPERATURE_PROVIDERS
+
+    def test_minimax_host_in_strict_providers(self):
+        """api.minimax.io should be in the strict temperature provider set."""
+        _, providers = self._get_service_module()
+        assert "api.minimax.io" in providers
+
+    def test_clamp_zero_temperature(self):
+        """Temperature 0.0 should be clamped to 0.01 for MiniMax."""
+        LLMService, _ = self._get_service_module()
+        result = LLMService._clamp_temperature(0.0, "https://api.minimax.io/v1")
+        assert result == 0.01
+
+    def test_clamp_negative_temperature(self):
+        """Negative temperature should be clamped to 0.01 for MiniMax."""
+        LLMService, _ = self._get_service_module()
+        result = LLMService._clamp_temperature(-1.0, "https://api.minimax.io/v1")
+        assert result == 0.01
+
+    def test_clamp_high_temperature(self):
+        """Temperature above 1.0 should be clamped to 1.0 for MiniMax."""
+        LLMService, _ = self._get_service_module()
+        result = LLMService._clamp_temperature(1.5, "https://api.minimax.io/v1")
+        assert result == 1.0
+
+    def test_clamp_normal_temperature(self):
+        """Valid temperature should pass through unchanged for MiniMax."""
+        LLMService, _ = self._get_service_module()
+        result = LLMService._clamp_temperature(0.7, "https://api.minimax.io/v1")
+        assert result == 0.7
+
+    def test_clamp_boundary_temperature_one(self):
+        """Temperature 1.0 is valid and should not change for MiniMax."""
+        LLMService, _ = self._get_service_module()
+        result = LLMService._clamp_temperature(1.0, "https://api.minimax.io/v1")
+        assert result == 1.0
+
+    def test_no_clamp_for_openai(self):
+        """Temperature should NOT be clamped for OpenAI provider."""
+        LLMService, _ = self._get_service_module()
+        result = LLMService._clamp_temperature(0.0, "https://api.openai.com/v1")
+        assert result == 0.0
+
+    def test_no_clamp_for_generic_provider(self):
+        """Temperature should NOT be clamped for unknown providers."""
+        LLMService, _ = self._get_service_module()
+        result = LLMService._clamp_temperature(2.0, "https://custom-api.example.com/v1")
+        assert result == 2.0
+
+    def test_clamp_very_small_positive(self):
+        """Very small positive temperature should pass for MiniMax."""
+        LLMService, _ = self._get_service_module()
+        result = LLMService._clamp_temperature(0.05, "https://api.minimax.io/v1")
+        assert result == 0.05
+
+
+# ============================================================
+# LLMService.__call__ integration with clamping
+# ============================================================
+
+
+class TestLLMServiceCallWithMiniMax:
+    """Test LLMService.__call__ applies temperature clamping for MiniMax."""
+
+    def _make_service(self):
+        from pixelle_video.services.llm_service import LLMService
+        return LLMService(config={})
+
+    @pytest.mark.asyncio
+    async def test_call_applies_temperature_clamping(self):
+        """When using MiniMax base_url, temperature should be clamped in the API call."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+        from pixelle_video.services.llm_service import LLMService
+
+        service = self._make_service()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Hello from MiniMax"
+
+        with patch.object(service, "_create_client") as mock_create:
+            mock_client = AsyncMock()
+            mock_client.base_url = "https://api.minimax.io/v1"
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+            mock_create.return_value = mock_client
+
+            with patch.object(service, "_get_config_value", return_value="MiniMax-M3"):
+                result = await service(
+                    prompt="Hello",
+                    base_url="https://api.minimax.io/v1",
+                    temperature=0.0,
+                )
+
+            assert result == "Hello from MiniMax"
+            call_kwargs = mock_client.chat.completions.create.call_args
+            assert call_kwargs.kwargs["temperature"] == 0.01
+
+    @pytest.mark.asyncio
+    async def test_call_no_clamp_for_openai(self):
+        """When using OpenAI base_url, temperature should NOT be clamped."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        service = self._make_service()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Hello from OpenAI"
+
+        with patch.object(service, "_create_client") as mock_create:
+            mock_client = AsyncMock()
+            mock_client.base_url = "https://api.openai.com/v1"
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+            mock_create.return_value = mock_client
+
+            with patch.object(service, "_get_config_value", return_value="gpt-4o"):
+                result = await service(
+                    prompt="Hello",
+                    base_url="https://api.openai.com/v1",
+                    temperature=0.0,
+                )
+
+            assert result == "Hello from OpenAI"
+            call_kwargs = mock_client.chat.completions.create.call_args
+            assert call_kwargs.kwargs["temperature"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_call_structured_output_with_minimax(self):
+        """Structured output should also clamp temperature for MiniMax."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+        from pydantic import BaseModel
+
+        class TestOutput(BaseModel):
+            text: str
+
+        service = self._make_service()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = '{"text": "hello"}'
+
+        with patch.object(service, "_create_client") as mock_create:
+            mock_client = AsyncMock()
+            mock_client.base_url = "https://api.minimax.io/v1"
+            mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+            mock_create.return_value = mock_client
+
+            with patch.object(service, "_get_config_value", return_value="MiniMax-M3"):
+                result = await service(
+                    prompt="Generate output",
+                    base_url="https://api.minimax.io/v1",
+                    temperature=0.0,
+                    response_type=TestOutput,
+                )
+
+            assert isinstance(result, TestOutput)
+            assert result.text == "hello"
+
+
+# ============================================================
+# LLM Utility - connection test with MiniMax URL
+# ============================================================
+
+
+class TestLLMUtilWithMiniMax:
+    """Test llm_util functions with MiniMax endpoint."""
+
+    def test_fetch_models_minimax_url(self):
+        """fetch_available_models should build correct URL for MiniMax."""
+        from unittest.mock import MagicMock, patch
+        from pixelle_video.utils.llm_util import fetch_available_models
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [
+                {"id": "MiniMax-M3"},
+                {"id": "MiniMax-M2.7"},
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response
+
+        with patch("pixelle_video.utils.llm_util.httpx.Client", return_value=mock_client):
+            models = fetch_available_models("test-key", "https://api.minimax.io/v1")
+
+        assert "MiniMax-M3" in models
+        assert "MiniMax-M2.7" in models
+        call_url = mock_client.get.call_args[0][0]
+        assert call_url == "https://api.minimax.io/v1/models"
+
+    def test_connection_test_minimax(self):
+        """test_llm_connection should work with MiniMax endpoint."""
+        from unittest.mock import patch
+        from pixelle_video.utils.llm_util import test_llm_connection
+
+        with patch(
+            "pixelle_video.utils.llm_util.fetch_available_models",
+            return_value=["MiniMax-M3", "MiniMax-M2.7"],
+        ):
+            success, message, count = test_llm_connection(
+                "test-key", "https://api.minimax.io/v1"
+            )
+
+        assert success is True
+        assert count == 2
+        assert "2" in message


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimax.io/) as a built-in LLM provider preset with **MiniMax-M3** set as the default model, giving users one-click access to a 512K context window, 128K max output, and image input support via an OpenAI-compatible API.

## Changes

- Add MiniMax preset to `llm_presets.py` (name, base_url, model = `MiniMax-M3`, api_key_url)
- Add temperature clamping in `LLMService` for MiniMax API (requires temperature in (0.0, 1.0])
- Strip `<think>` tags from structured output responses for MiniMax compatibility
- Update README.md and README_EN.md to mention MiniMax in supported models and recommended solutions
- Add MiniMax preset comment in `config.example.yaml`
- Add 21 unit tests and 3 integration tests

## Why M3 as default

`MiniMax-M3` is the latest model: 512K context window, up to 128K output, and image input support. Users can still switch to `MiniMax-M2.7` or `MiniMax-M2.7-highspeed` by overriding the model field.

## Test Plan

- [x] 21 unit tests pass (preset validation, temperature clamping, mock LLM calls, utility functions)
- [x] 3 integration tests pass against live MiniMax API (basic call, temperature clamping, structured output)
- [ ] Manual test: select MiniMax preset in Web UI, verify auto-fill of base_url and model