### PR TITLE
fix: playwright not found in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN export UV_HTTP_TIMEOUT=300 && \
     else \
         uv pip install -e .; \
     fi && \
-    playwright install --with-deps chromium
+    uv run playwright install --with-deps chromium
 
 # Copy rest of application code
 COPY api ./api


### PR DESCRIPTION
Fixes `playwright: not found` error during Docker build by using `uv run playwright install` instead of direct `playwright install`.

The issue occurred because playwright is installed in the uv virtual environment, but the install command was called outside of it.

<img width="934" height="133" alt="image" src="https://github.com/user-attachments/assets/926911fc-c453-4f19-9684-481507068982" />

