### PR TITLE
Simplify models URL construction for broader endpoint support

### DIFF
--- a/pixelle_video/utils/llm_util.py
+++ b/pixelle_video/utils/llm_util.py
@@ -43,11 +43,7 @@ def fetch_available_models(api_key: str, base_url: str, timeout: float = 10.0) -
     base_url = base_url.rstrip("/")
     
     # Build the models endpoint URL
-    # Handle cases where base_url might or might not include /v1
-    if base_url.endswith("/v1"):
-        models_url = f"{base_url}/models"
-    else:
-        models_url = f"{base_url}/v1/models"
+    models_url = f"{base_url}/models"
     
     headers = {
         "Authorization": f"Bearer {api_key}",


### PR DESCRIPTION
## Summary
Remove `/v1` suffix check to support custom base URLs (e.g., GLM's `/api/coding/paas/v4`).

## Change
```python
# Before: Conditional logic based on /v1 suffix
# After: models_url = f"{base_url}/models"
