### PR TITLE
fix: guard cancel_task against overwriting terminal task status

### DIFF
--- a/api/tasks/manager.py
+++ b/api/tasks/manager.py
@@ -220,6 +220,10 @@ class TaskManager:
         if not task:
             return False
         
+        # Do not cancel already-terminal tasks
+        if task.status in [TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED]:
+            return False
+
         # Cancel future if running
         future = self._task_futures.get(task_id)
         if future and not future.done():


### PR DESCRIPTION
## Summary\n\nFixes #95\n\nThe `cancel_task` method in `api/tasks/manager.py` was overwriting the status of already-completed, failed, or cancelled tasks. This means calling `DELETE /api/tasks/{task_id}` on a completed task would silently change its status to `CANCELLED`.\n\n## Change\n\nAdded a guard that returns `False` early if the task is already in a terminal state (`COMPLETED`, `FAILED`, or `CANCELLED`):\n\n\n\nThis causes the router to correctly return 404 when attempting to cancel a task that no longer can be cancelled.