### PR TITLE
fix: correct MiniMax base_url to api.minimax.chat

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,6 +15,7 @@ llm:
 # Qwen Max:        base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1"  model: "qwen-max"
 # OpenAI GPT-4o:   base_url: "https://api.openai.com/v1"                          model: "gpt-4o"
 # DeepSeek:        base_url: "https://api.deepseek.com"                           model: "deepseek-chat"
+# MiniMax:         base_url: "https://api.minimax.chat/v1"                          model: "MiniMax-Text-01"
 # Ollama (Local):  base_url: "http://localhost:11434/v1"                          model: "llama3.2"
 
 # ==================== ComfyUI Configuration ====================

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,7 +15,7 @@ llm:
 # Qwen Max:        base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1"  model: "qwen-max"
 # OpenAI GPT-4o:   base_url: "https://api.openai.com/v1"                          model: "gpt-4o"
 # DeepSeek:        base_url: "https://api.deepseek.com"                           model: "deepseek-chat"
-# MiniMax:         base_url: "https://api.minimax.chat/v1"                          model: "MiniMax-Text-01"
+# MiniMax:         base_url: "https://api.minimax.chat/v1"                          model: "MiniMax-M2.7"
 # Ollama (Local):  base_url: "http://localhost:11434/v1"                          model: "llama3.2"
 
 # ==================== ComfyUI Configuration ====================

--- a/pixelle_video/llm_presets.py
+++ b/pixelle_video/llm_presets.py
@@ -54,7 +54,7 @@ LLM_PRESETS: List[Dict[str, Any]] = [
     {
         "name": "MiniMax",
         "base_url": "https://api.minimax.chat/v1",
-        "model": "MiniMax-Text-01",
+        "model": "MiniMax-M2.7",
         "api_key_url": "https://platform.minimaxi.com/user-center/basic-information/interface-key",
     },
     {

--- a/pixelle_video/llm_presets.py
+++ b/pixelle_video/llm_presets.py
@@ -52,6 +52,12 @@ LLM_PRESETS: List[Dict[str, Any]] = [
         "default_api_key": "ollama",  # Required by OpenAI SDK but ignored by Ollama
     },
     {
+        "name": "MiniMax",
+        "base_url": "https://api.minimax.chat/v1",
+        "model": "MiniMax-Text-01",
+        "api_key_url": "https://platform.minimaxi.com/user-center/basic-information/interface-key",
+    },
+    {
         "name": "Moonshot",
         "base_url": "https://api.moonshot.cn/v1",
         "model": "moonshot-v1-8k",


### PR DESCRIPTION
## Problem
PR #77 introduced MiniMax support but uses `api.minimax.io` as the base URL, which cannot successfully fetch the model list.

## Fix
Change base URL from `https://api.minimax.io/v1` to `https://api.minimax.chat/v1`. The latter has been verified to return the correct model list (e.g. MiniMax-Text-01).

This is a targeted fix for the URL issue in #77.