### PR TITLE
Fix Windows Playwright HTML rendering under Streamlit

### DIFF
--- a/pixelle_video/services/frame_html.py
+++ b/pixelle_video/services/frame_html.py
@@ -25,6 +25,7 @@ Linux Environment Requirements:
     Playwright browser install: playwright install --with-deps chromium
 """
 
+import asyncio
 import os
 import re
 import tempfile
@@ -55,6 +56,7 @@ class HTMLFrameGenerator:
     
     _browser = None
     _playwright = None
+    _browser_loop = None
 
     def __init__(self, template_path: str):
         """
@@ -307,7 +309,22 @@ class HTMLFrameGenerator:
     @classmethod
     async def _ensure_browser(cls):
         """Lazily initialize a shared Playwright browser instance"""
-        if cls._browser is None or not cls._browser.is_connected():
+        current_loop = asyncio.get_running_loop()
+        browser_usable = (
+            cls._browser is not None
+            and cls._browser_loop is current_loop
+            and cls._browser.is_connected()
+        )
+
+        if not browser_usable:
+            if cls._browser is not None and cls._browser_loop is not current_loop:
+                logger.warning(
+                    "Detected cross-loop Playwright browser reuse attempt; "
+                    "recreating browser for current event loop"
+                )
+
+            cls._browser = None
+            cls._playwright = None
             from playwright.async_api import async_playwright
             cls._playwright = await async_playwright().start()
             cls._browser = await cls._playwright.chromium.launch(
@@ -318,6 +335,7 @@ class HTMLFrameGenerator:
                     '--disable-extensions',
                 ]
             )
+            cls._browser_loop = current_loop
             logger.debug("Initialized Playwright Chromium browser")
         return cls._browser
 
@@ -327,6 +345,7 @@ class HTMLFrameGenerator:
         if cls._browser:
             await cls._browser.close()
             cls._browser = None
+            cls._browser_loop = None
         if cls._playwright:
             await cls._playwright.stop()
             cls._playwright = None
@@ -410,5 +429,7 @@ class HTMLFrameGenerator:
             return output_path
             
         except Exception as e:
-            logger.error(f"Failed to render HTML template: {e}")
-            raise RuntimeError(f"HTML rendering failed: {e}")
+            logger.exception("Failed to render HTML template")
+            raise RuntimeError(
+                f"HTML rendering failed: {type(e).__name__}: {e}"
+            ) from e

--- a/web/utils/async_helpers.py
+++ b/web/utils/async_helpers.py
@@ -15,6 +15,7 @@ Async helper functions for web UI
 """
 
 import asyncio
+import sys
 import tomllib
 from pathlib import Path
 
@@ -23,6 +24,23 @@ from loguru import logger
 
 def run_async(coro):
     """Run async coroutine in sync context"""
+    if sys.platform == "win32":
+        # Streamlit/Tornado may switch the global asyncio policy to
+        # WindowsSelectorEventLoopPolicy, which breaks subprocess-based
+        # libraries such as Playwright on Windows. Use an explicit
+        # Proactor loop here so this sync bridge does not depend on the
+        # ambient global policy.
+        loop = asyncio.ProactorEventLoop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            try:
+                from pixelle_video.services.frame_html import HTMLFrameGenerator
+
+                loop.run_until_complete(HTMLFrameGenerator.close_browser())
+            except Exception as e:
+                logger.debug(f"Failed to cleanup HTML frame browser before loop close: {e}")
+            loop.close()
     return asyncio.run(coro)
 
 


### PR DESCRIPTION
## Summary
- run Playwright-backed HTML rendering on an explicit Proactor event loop on Windows
- recreate the shared Playwright browser when a new event loop is used
- preserve the original exception type in HTML rendering failures for easier diagnosis

## Root cause
Streamlit/Tornado can switch the global asyncio policy on Windows to `WindowsSelectorEventLoopPolicy`. The UI sync bridge was using `asyncio.run(...)`, so HTML frame rendering ended up on a selector loop. Playwright launches browser subprocesses, which are not supported there on Windows, leading to `NotImplementedError` from `_make_subprocess_transport` and the user-facing `HTML rendering failed` error.

## Validation
- confirmed the Streamlit runtime was using `WindowsSelectorEventLoopPolicy`
- verified static and image template previews through the real Streamlit UI
- verified a minimal end-to-end video generation succeeded after the fix
- verified local TTS, RunningHub TTS, and RunningHub image preview paths still worked without reintroducing browser startup or loop shutdown issues