### PR TITLE
Home页面添加Gemini模型支持

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,6 +15,7 @@ llm:
 # Qwen Max:        base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1"  model: "qwen-max"
 # OpenAI GPT-4o:   base_url: "https://api.openai.com/v1"                          model: "gpt-4o"
 # DeepSeek:        base_url: "https://api.deepseek.com"                           model: "deepseek-chat"
+# Gemini           base_url: "https://generativelanguage.googleapis.com/v1beta"   model: "gemini-3-flash-preview"
 # Ollama (Local):  base_url: "http://localhost:11434/v1"                          model: "llama3.2"
 
 # ==================== ComfyUI Configuration ====================

--- a/pixelle_video/llm_presets.py
+++ b/pixelle_video/llm_presets.py
@@ -57,6 +57,12 @@ LLM_PRESETS: List[Dict[str, Any]] = [
         "model": "moonshot-v1-8k",
         "api_key_url": "https://platform.moonshot.cn/console/api-keys",
     },
+    {
+        "name": "Gemini",
+        "base_url": "https://generativelanguage.googleapis.com/v1beta",
+        "model": "gemini-3-flash-preview",
+        "api_key_url": "https://aistudio.google.com/app/api-keys",
+    },
 ]
 
 

--- a/pixelle_video/utils/llm_util.py
+++ b/pixelle_video/utils/llm_util.py
@@ -41,19 +41,27 @@ def fetch_available_models(api_key: str, base_url: str, timeout: float = 10.0) -
     """
     # Normalize base_url - ensure it ends with /v1 or similar
     base_url = base_url.rstrip("/")
-    
+
+    for_gemini = False
     # Build the models endpoint URL
     # Handle cases where base_url might or might not include /v1
     if base_url.endswith("/v1"):
         models_url = f"{base_url}/models"
     else:
         models_url = f"{base_url}/v1/models"
-    
+
+    if base_url.endswith("v1beta"):
+        for_gemini = True
+
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
-    
+    if for_gemini:
+        models_url = f"{base_url}/models"
+        headers = {"x-goog-api-key": f"{api_key}",
+                   "Content-Type": "application/json"
+        }
     logger.debug(f"Fetching models from: {models_url}")
     
     with httpx.Client(timeout=timeout) as client:
@@ -62,7 +70,8 @@ def fetch_available_models(api_key: str, base_url: str, timeout: float = 10.0) -
         
         data = response.json()
         models = [model["id"] for model in data.get("data", [])]
-        
+        if for_gemini:
+            models = [model["name"] for model in data.get("models", [])]
         # Sort models alphabetically for better UX
         models.sort()
         


### PR DESCRIPTION
在配置页面添加了Gemini支持，本地测试可正常获取Gemini模型列表以及生成视频，不影响其他原有模型