### PR TITLE
fix: remove broken CLI entry points referencing non-existent cli module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,6 @@ dev = [
     "ruff>=0.6.0",
 ]
 
-[project.scripts]
-pixelle-video = "pixelle_video.cli:main"
-pvideo = "pixelle_video.cli:main"
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary
- `pyproject.toml` defines console scripts `pixelle-video` and `pvideo` pointing to `pixelle_video.cli:main`
- The `pixelle_video/cli.py` module does not exist in the repository
- Running either command after `pip install` crashes with `ModuleNotFoundError: No module named 'pixelle_video.cli'`
- Removed the `[project.scripts]` section since the app is launched via `streamlit run web/app.py`

## Test plan
- [x] Verified `pixelle_video/cli.py` does not exist
- [x] Verified the project is started via `uv run streamlit run web/app.py` (see `start_web.sh`)
- [x] No other code references `pixelle_video.cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)