### PR TITLE
fix: handle videos without audio in _trim_video_to_duration

### DIFF
--- a/pixelle_video/services/video.py
+++ b/pixelle_video/services/video.py
@@ -907,10 +907,13 @@ class VideoService:
         
         try:
             # Use stream copy when possible for fast trimming
+            input_stream = ffmpeg.input(video, t=target_duration)
+            output_kwargs = {"vcodec": "copy"}
+            if self.has_audio_stream(video):
+                output_kwargs["acodec"] = "copy"
             (
-                ffmpeg
-                .input(video, t=target_duration)
-                .output(output, vcodec='copy', acodec='copy' if self.has_audio_stream(video) else 'copy')
+                input_stream
+                .output(output, **output_kwargs)
                 .overwrite_output()
                 .run(capture_stdout=True, capture_stderr=True, quiet=True)
             )


### PR DESCRIPTION
## Summary
- `_trim_video_to_duration` in `services/video.py` has a dead ternary expression:
  ```python
  acodec='copy' if self.has_audio_stream(video) else 'copy'
  ```
  Both branches return `'copy'`, making the condition meaningless.
- When a video has no audio stream, specifying `acodec='copy'` causes FFmpeg to fail with
  "Stream specifier:a:0 does not match any streams."
- This commonly occurs with AI-generated videos or image-to-video conversions that produce silent output.

## Fix
Only specify `acodec='copy'` when the video actually has an audio stream.

## Test plan
- [x] Verified `has_audio_stream()` is already used correctly elsewhere in the same class
- [x] Logic matches how other methods in `VideoService` handle audio-optional videos

🤖 Generated with [Claude Code](https://claude.com/claude-code)