### PR TITLE
fix: remove duplicate delete_task that doesn't update index

### DIFF
--- a/pixelle_video/services/persistence.py
+++ b/pixelle_video/services/persistence.py
@@ -315,26 +315,7 @@ class PersistenceService:
     async def task_exists(self, task_id: str) -> bool:
         """Check if task exists"""
         return self.get_task_dir(task_id).exists()
-    
-    async def delete_task(self, task_id: str):
-        """
-        Delete task directory and all files
-        
-        Args:
-            task_id: Task ID
-        """
-        try:
-            task_dir = self.get_task_dir(task_id)
-            
-            if task_dir.exists():
-                import shutil
-                shutil.rmtree(task_dir)
-                logger.info(f"Deleted task: {task_id}")
-            
-        except Exception as e:
-            logger.error(f"Failed to delete task {task_id}: {e}")
-            raise
-    
+
     # ========================================================================
     # Serialization Helpers
     # ========================================================================


### PR DESCRIPTION
## Summary
- `PersistenceService` defined `delete_task` twice (lines 319 and 683)
- The first definition (now removed) only deleted the task directory but **did not update the index file**, leaving stale entries
- The second definition properly removes the task from the index via `_load_index()`/`_save_index()`
- In Python, the second definition overrides the first, so the first was dead code
- Removing it prevents confusion about which behavior is active

## Test plan
- [x] Verified the second `delete_task` at the bottom of the class still exists and handles index updates
- [x] No other code references the first definition specifically

🤖 Generated with [Claude Code](https://claude.com/claude-code)