### PR TITLE
fix(asset_based): handle scenes with empty narrations list

### DIFF
--- a/pixelle_video/pipelines/asset_based.py
+++ b/pixelle_video/pipelines/asset_based.py
@@ -49,6 +49,23 @@ from pixelle_video.utils.os_util import (
 ProgressCallback = Optional[Callable[[ProgressEvent], None]]
 
 
+def _coerce_narrations(scene: dict) -> List[str]:
+    """Read narrations from a scene, normalized to a non-empty list."""
+    raw = scene.get("narrations")
+    if raw is None:
+        raw = scene.get("narration", "")
+
+    if isinstance(raw, str):
+        items = [raw]
+    elif isinstance(raw, list):
+        items = [str(x) for x in raw]
+    else:
+        items = []
+
+    items = [s.strip() for s in items if s and s.strip()]
+    return items if items else [""]
+
+
 # ==================== Structured Output Models ====================
 
 class SceneScript(BaseModel):
@@ -379,9 +396,7 @@ class AssetBasedPipeline(LinearVideoPipeline):
         
         # Log script preview
         for scene in context.script:
-            narrations = scene.get("narrations", [])
-            if isinstance(narrations, str):
-                narrations = [narrations]
+            narrations = _coerce_narrations(scene)
             narration_preview = " | ".join([n[:30] + "..." if len(n) > 30 else n for n in narrations[:2]])
             asset_name = Path(scene.get("asset_path", "unknown")).name
             logger.info(f"Scene {scene['scene_number']} [{asset_name}]: {narration_preview}")
@@ -445,9 +460,7 @@ class AssetBasedPipeline(LinearVideoPipeline):
         # Extract all narrations in order for compatibility
         all_narrations = []
         for scene in context.matched_scenes:
-            narrations = scene.get("narrations", [scene.get("narration", "")])
-            if isinstance(narrations, str):
-                narrations = [narrations]
+            narrations = _coerce_narrations(scene)
             all_narrations.extend(narrations)
         
         context.narrations = all_narrations
@@ -492,9 +505,7 @@ class AssetBasedPipeline(LinearVideoPipeline):
         # Create StoryboardFrames - one per scene
         for i, scene in enumerate(context.matched_scenes):
             # Get first narration for the frame (we'll combine audios later)
-            narrations = scene.get("narrations", [scene.get("narration", "")])
-            if isinstance(narrations, str):
-                narrations = [narrations]
+            narrations = _coerce_narrations(scene)
             
             # Use first narration as the main text (for subtitle)
             # We'll combine all narrations in the audio
@@ -567,15 +578,15 @@ class AssetBasedPipeline(LinearVideoPipeline):
             
             # Get scene data with narrations
             scene = frame._scene_data
-            narrations = scene.get("narrations", [scene.get("narration", "")])
-            if isinstance(narrations, str):
-                narrations = [narrations]
+            narrations = _coerce_narrations(scene)
             
             logger.info(f"Scene {i} has {len(narrations)} narration(s)")
             
             # Step 1: Generate audio for each narration and combine
             narration_audios = []
             for j, narration_text in enumerate(narrations, 1):
+                if not narration_text.strip():
+                    continue
                 audio_path = Path(context.task_dir) / "frames" / f"{i:02d}_narration_{j}.mp3"
                 audio_path.parent.mkdir(parents=True, exist_ok=True)
                 
@@ -590,8 +601,26 @@ class AssetBasedPipeline(LinearVideoPipeline):
                 logger.debug(f"  Narration {j}/{len(narrations)}: {narration_text[:30]}...")
             
             # Concatenate all narration audios for this scene
-            if len(narration_audios) > 1:
-                from pixelle_video.utils.os_util import get_task_frame_path
+            if not narration_audios:
+                import subprocess
+
+                silent_audio_path = Path(context.task_dir) / "frames" / f"{i:02d}_silent.mp3"
+                silent_audio_path.parent.mkdir(parents=True, exist_ok=True)
+                subprocess.run(
+                    [
+                        "ffmpeg",
+                        "-f", "lavfi",
+                        "-i", "anullsrc=r=44100:cl=mono",
+                        "-t", "3",
+                        "-q:a", "9",
+                        "-y", str(silent_audio_path)
+                    ],
+                    check=True,
+                    capture_output=True,
+                )
+                frame.audio_path = str(silent_audio_path)
+                logger.warning(f"Scene {i} has no narration; using 3s silent audio")
+            elif len(narration_audios) > 1:
                 
                 # Emit progress for combining audio
                 frame_progress = base_progress + ((i - 1) + 0.25) / total_frames * progress_range


### PR DESCRIPTION
## Summary

The `asset_based` pipeline (custom_media in the UI) crashes with `IndexError: list index out of range` when a scene has an empty `narrations` list. This is a legitimate LLM output for cover slides, chapter dividers, or any purely-visual scene — it is reliably reproducible by uploading a title slide as the first asset.

## Reproduction

1. Open the **Custom Media (自定义素材)** pipeline.
2. Upload 9 PPT slide images. The first slide is a cover with no spoken narration.
3. Provide an article / intent and click **Generate**.

Observed log:

```
INFO  asset_based:initialize_storyboard:530 - ✅ Created storyboard with 9 scenes
INFO  asset_based:produce_assets:544 - 🎬 Producing scene videos...
INFO  asset_based:produce_assets:555 - Producing scene 1/9...
INFO  asset_based:produce_assets:574 - Scene 1 has 0 narration(s)
ERROR linear:handle_exception:161 - Pipeline execution failed: list index out of range
```

The pipeline aborts before any video is produced.

## Root cause

The same defensive read pattern appears in **four** places:

```python
narrations = scene.get("narrations", [scene.get("narration", "")])
if isinstance(narrations, str):
    narrations = [narrations]
```

It guards against missing keys and string values, but **does not handle `narrations` being an empty list** (which happens when LLM legitimately decides a scene has no narration). All four call sites silently degrade or crash:

| Location | Behavior on empty `narrations` |
| --- | --- |
| L382 (log preview) | Empty preview line, hides the gap |
| L448-453 (`all_narrations.extend`) | Scene silently disappears from `context.narrations` |
| L495-505 (`StoryboardFrame.narration`) | Empty subtitle string |
| **L570-635 (TTS production)** | 💥 `IndexError` at `narration_audios[0]` (L635) — user-facing crash |

Only the last one crashes, but the other three create silent data drift that is harder to diagnose later.

## Fix

1. **Centralize the read** with a single `_coerce_narrations(scene)` helper that normalizes any of `{missing, None, str, list, list-with-empty-strings}` into a non-empty list of stripped, non-empty strings, falling back to `[""]` when the scene is genuinely silent. The fallback preserves the existing length-based assumptions (`len(narrations) >= 1`) so callers can still index safely; callers that care about content can detect the gap via the empty string.

2. **Replace all four call sites** with `narrations = _coerce_narrations(scene)`.

3. **In the TTS loop** (`produce_assets`):
   - Skip empty narration text (don't waste a TTS call).
   - When a scene produces zero audio segments, synthesize a 3-second silent track with ffmpeg (`anullsrc`) so downstream composition still has a valid `audio_path`. This lets cover slides render as a 3-second silent shot instead of crashing.

The single-narration and multi-narration concat branches are unchanged.

## Diff size

`pixelle_video/pipelines/asset_based.py`: +43 / −14 lines, single file.

## Verification

- Reproduced the crash with a 9-slide PPT (slide 1 = cover with no narration).
- After the fix, the pipeline completes; slide 1 plays as a 3-second silent shot, scenes 2–9 narrate normally.
- Single-narration and multi-narration scenes are unaffected (verified via the existing branches at L623-664).

## Out of scope

- Whether the cover slide should get LLM-generated narration in the first place is a separate question (a cover-detection heuristic in `generate_content` would be one path). This PR only ensures the pipeline does not crash when LLM legitimately decides a scene has no narration.
- The 3-second silent fallback duration is currently hardcoded; making it configurable (e.g. `config.cover_silent_duration`) is a follow-up.

## Why no tests

The pipeline depends on LLM, ffmpeg, and a runtime task directory; there is no existing unit-test scaffold for `produce_assets`. `_coerce_narrations` itself is a pure function and trivially testable if the project later adopts a test harness — happy to add tests in a follow-up if the maintainer wants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)