### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,6 +16,8 @@ llm:
 # OpenAI GPT-4o:   base_url: "https://api.openai.com/v1"                          model: "gpt-4o"
 # DeepSeek:        base_url: "https://api.deepseek.com"                           model: "deepseek-chat"
 # Ollama (Local):  base_url: "http://localhost:11434/v1"                          model: "llama3.2"
+# Astraflow:        base_url: "https://api-us-ca.umodelverse.ai/v1"              model: "gpt-4o"
+# Astraflow CN:      base_url: "https://api.modelverse.cn/v1"                    model: "gpt-4o"
 
 # ==================== ComfyUI Configuration ====================
 comfyui:

--- a/pixelle_video/llm_presets.py
+++ b/pixelle_video/llm_presets.py
@@ -57,6 +57,18 @@ LLM_PRESETS: List[Dict[str, Any]] = [
         "model": "moonshot-v1-8k",
         "api_key_url": "https://platform.moonshot.cn/console/api-keys",
     },
+    {
+        "name": "Astraflow",
+        "base_url": "https://api-us-ca.umodelverse.ai/v1",
+        "model": "gpt-4o",
+        "api_key_url": "https://astraflow.ucloud-global.com",
+    },
+    {
+        "name": "Astraflow CN",
+        "base_url": "https://api.modelverse.cn/v1",
+        "model": "gpt-4o",
+        "api_key_url": "https://astraflow.ucloud.cn",
+    },
 ]
 
 


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得) as a supported LLM provider preset.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models. Because it is fully OpenAI SDK–compatible, the integration only requires adding the `base_url` and `api_key_url` — no new SDK or subpackage needed.

## Changes

### `pixelle_video/llm_presets.py`
- Added `"Astraflow"` preset (global endpoint: `https://api-us-ca.umodelverse.ai/v1`)
- Added `"Astraflow CN"` preset (China endpoint: `https://api.modelverse.cn/v1`)

### `config.example.yaml`
- Added comment examples for both Astraflow global and China endpoints under the LLM presets section

## Provider Details

| Field | Global | China |
|---|---|---|
| `base_url` | `https://api-us-ca.umodelverse.ai/v1` | `https://api.modelverse.cn/v1` |
| API key signup | https://astraflow.ucloud-global.com | https://astraflow.ucloud.cn |
| Env var | `ASTRAFLOW_API_KEY` | `ASTRAFLOW_CN_API_KEY` |

Both endpoints follow the same OpenAI SDK protocol already used by every other preset in this project.