### PR TITLE
feat(agnes): 接入 Agnes 图像和视频模型

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -35,6 +35,10 @@ api_providers:
     api_key: ""
     base_url: "https://ark.cn-beijing.volces.com/api/v3"
     use_proxy: false
+  agnes:
+    api_key: ""
+    base_url: "https://apihub.agnes-ai.com/v1"
+    use_proxy: false
   kling:
     base_url: "https://api-beijing.klingai.com"
     access_key: ""

--- a/pixelle_video/config/schema.py
+++ b/pixelle_video/config/schema.py
@@ -16,6 +16,7 @@ Configuration schema with Pydantic models
 Single source of truth for all configuration defaults and validation.
 """
 from typing import Optional
+
 from pydantic import BaseModel, Field
 
 
@@ -55,6 +56,7 @@ class APIProvidersConfig(BaseModel):
     deepseek: APIKeyProviderConfig = Field(default_factory=APIKeyProviderConfig)
     gemini: APIKeyProviderConfig = Field(default_factory=APIKeyProviderConfig)
     ark: APIKeyProviderConfig = Field(default_factory=APIKeyProviderConfig)
+    agnes: APIKeyProviderConfig = Field(default_factory=APIKeyProviderConfig)
     kling: AccessSecretProviderConfig = Field(default_factory=AccessSecretProviderConfig)
 
 

--- a/pixelle_video/llm_presets.py
+++ b/pixelle_video/llm_presets.py
@@ -16,8 +16,7 @@ LLM Presets - Predefined configurations for popular LLM providers
 All providers support OpenAI SDK protocol.
 """
 
-from typing import Dict, Any, List
-
+from typing import Any, Dict, List
 
 LLM_PRESETS: List[Dict[str, Any]] = [
     {
@@ -31,6 +30,18 @@ LLM_PRESETS: List[Dict[str, Any]] = [
         "base_url": "https://api.openai.com/v1",
         "model": "gpt-4o",
         "api_key_url": "https://platform.openai.com/api-keys",
+    },
+    {
+        "name": "Agnes 2.0 Flash",
+        "base_url": "https://apihub.agnes-ai.com/v1",
+        "model": "agnes-2.0-flash",
+        "api_key_url": "https://platform.agnes-ai.com/",
+    },
+    {
+        "name": "Agnes 1.5 Flash",
+        "base_url": "https://apihub.agnes-ai.com/v1",
+        "model": "agnes-1.5-flash",
+        "api_key_url": "https://platform.agnes-ai.com/",
     },
     {
         "name": "Claude",
@@ -84,4 +95,3 @@ def find_preset_by_base_url_and_model(base_url: str, model: str) -> str | None:
         if preset["base_url"] == base_url and preset["model"] == model:
             return preset["name"]
     return None
-

--- a/pixelle_video/services/api_media.py
+++ b/pixelle_video/services/api_media.py
@@ -5,8 +5,8 @@
 """Direct API provider media generation adapter."""
 
 import asyncio
-from copy import deepcopy
 import os
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Optional
 
@@ -34,6 +34,10 @@ class APIProviderMediaService:
             "doubao-seedream-4-5-251128",
             "doubao-seedream-4-0-250828",
         ],
+        "agnes": [
+            "agnes-image-2.1-flash",
+            "agnes-image-2.0-flash",
+        ],
     }
 
     VIDEO_MODELS = {
@@ -58,6 +62,9 @@ class APIProviderMediaService:
             "doubao-seedance-2-0-fast-260128",
             "seedance-1-0-pro",
             "seedance-1-0-lite",
+        ],
+        "agnes": [
+            "agnes-video-v2.0",
         ],
     }
 
@@ -373,6 +380,28 @@ class APIProviderMediaService:
                 "Exact official model ID was not found. Volcengine docs refer to doubao-seedance model IDs, so this alias must be confirmed before relying on it.",
             ],
         },
+        ("agnes", "agnes-video-v2.0"): {
+            "ability_type": "text_to_video",
+            "ability_types": ["text_to_video", "image_to_video", "native_audio"],
+            "adapter_ability_types": ["text_to_video", "first_frame_i2v", "native_audio"],
+            "input_modalities": ["text", "image"],
+            "adapter_input_modalities": ["text", "image"],
+            "duration": {"min": 1, "max": 15, "integer": True, "verified": False},
+            "resolutions": ["720P", "1080P"],
+            "ratios": ["16:9", "9:16", "1:1", "4:3", "3:4", "21:9"],
+            "fps": 24,
+            "format": "mp4",
+            "api_contract_verified": True,
+            "source_urls": [
+                "https://agnes-ai.com/doc/agnes-video-v20",
+                "https://cloud.tencent.com/developer/article/2683093",
+            ],
+            "contract_issues": [
+                "Adapter follows the documented POST /v1/videos flow and prefers the recommended GET /agnesapi?video_id=... result retrieval when video_id is returned.",
+                "Agnes image-to-video requires a public image URL; local uploaded files cannot be sent directly.",
+                "Adapter maps Pixelle ratio/resolution to width/height and normalizes num_frames to the required 8n + 1 rule.",
+            ],
+        },
     }
 
     def __init__(self, config: dict, core=None):
@@ -477,7 +506,6 @@ class APIProviderMediaService:
         image_paths: Optional[list[str]] = None,
         **params,
     ) -> MediaResult:
-        from pixelle_video.services.api_services.image_client import ImageClient
 
         client = self._create_image_client()
         save_dir = self._save_dir(output_path, "api_images")
@@ -520,7 +548,6 @@ class APIProviderMediaService:
         height: Optional[int],
         **params,
     ) -> MediaResult:
-        from pixelle_video.services.api_services.video_client import VideoClient
 
         first_clip_path = params.get("first_clip_path") or params.get("first_video_path")
         reference_image_path = params.get("reference_image_path")
@@ -680,6 +707,9 @@ class APIProviderMediaService:
             ark_api_key=cfg["ark"].get("api_key") or None,
             ark_base_url=cfg["ark"].get("base_url") or None,
             ark_local_proxy=local_proxy if cfg["ark"].get("use_proxy") else None,
+            agnes_api_key=cfg["agnes"].get("api_key") or None,
+            agnes_base_url=cfg["agnes"].get("base_url") or None,
+            agnes_local_proxy=local_proxy if cfg["agnes"].get("use_proxy") else None,
         )
 
     def _create_video_client(self):
@@ -698,6 +728,9 @@ class APIProviderMediaService:
             ark_api_key=cfg["ark"].get("api_key") or None,
             ark_base_url=cfg["ark"].get("base_url") or None,
             ark_local_proxy=local_proxy if cfg["ark"].get("use_proxy") else None,
+            agnes_api_key=cfg["agnes"].get("api_key") or None,
+            agnes_base_url=cfg["agnes"].get("base_url") or None,
+            agnes_local_proxy=local_proxy if cfg["agnes"].get("use_proxy") else None,
         )
 
     def _save_dir(self, output_path: Optional[str], fallback_name: str) -> str:
@@ -752,6 +785,9 @@ class APIProviderMediaService:
 
         if provider == "seedance":
             return min(max(duration, 5), 10)
+
+        if provider == "agnes":
+            return min(max(duration, 1), 15)
 
         return max(duration, 1)
 
@@ -809,6 +845,13 @@ class APIProviderMediaService:
             options.update(
                 {
                     "generate_audio": params.get("generate_audio"),
+                }
+            )
+        elif provider == "agnes":
+            options.update(
+                {
+                    "frame_rate": params.get("frame_rate"),
+                    "num_inference_steps": params.get("num_inference_steps"),
                 }
             )
 

--- a/pixelle_video/services/api_services/config.py
+++ b/pixelle_video/services/api_services/config.py
@@ -34,6 +34,8 @@ class _ConfigMeta(type):
             "GOOGLE_GEMINI_BASE_URL": ("gemini", "base_url", ""),
             "ARK_API_KEY": ("ark", "api_key", ""),
             "ARK_BASE_URL": ("ark", "base_url", ""),
+            "AGNES_API_KEY": ("agnes", "api_key", ""),
+            "AGNES_BASE_URL": ("agnes", "base_url", ""),
             "KLING_BASE_URL": ("kling", "base_url", ""),
             "KLING_ACCESS_KEY": ("kling", "access_key", ""),
             "KLING_SECRET_KEY": ("kling", "secret_key", ""),

--- a/pixelle_video/services/api_services/image_agnes.py
+++ b/pixelle_video/services/api_services/image_agnes.py
@@ -1,0 +1,165 @@
+"""Agnes image generation client."""
+
+import base64
+import mimetypes
+import os
+import time
+import uuid
+from typing import Optional
+
+import requests
+from loguru import logger
+
+AGNES_BASE_URL = "https://apihub.agnes-ai.com/v1"
+
+
+def _proxy_dict(local_proxy: Optional[str]) -> Optional[dict]:
+    if not local_proxy:
+        return None
+    return {"http": local_proxy, "https": local_proxy}
+
+
+class AgnesImageClient:
+    """Client for Agnes Image 2.x Flash models."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        local_proxy: Optional[str] = None,
+        timeout: int = 300,
+    ) -> None:
+        self.api_key = api_key or os.getenv("AGNES_API_KEY", "")
+        self.base_url = (base_url or os.getenv("AGNES_BASE_URL") or AGNES_BASE_URL).rstrip("/")
+        self.local_proxy = local_proxy
+        self.timeout = timeout
+
+        if not self.api_key:
+            logger.warning("AgnesImageClient: AGNES_API_KEY 未设置")
+
+    def _headers(self) -> dict:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _proxies(self) -> Optional[dict]:
+        return _proxy_dict(self.local_proxy)
+
+    @staticmethod
+    def _image_to_url(image_path: str) -> str:
+        if image_path.startswith(("http://", "https://", "data:")):
+            return image_path
+
+        if not os.path.exists(image_path):
+            raise FileNotFoundError(f"输入图片不存在: {image_path}")
+
+        mime = mimetypes.guess_type(image_path)[0] or "image/jpeg"
+        with open(image_path, "rb") as f:
+            encoded = base64.b64encode(f.read()).decode("utf-8")
+        return f"data:{mime};base64,{encoded}"
+
+    @staticmethod
+    def _normalize_size(size: str) -> str:
+        normalized = (size or "1024x1024").replace("*", "x")
+        allowed = {"1024x1024", "1792x1024", "1024x1792"}
+        if normalized in allowed:
+            return normalized
+
+        try:
+            width, height = [int(part) for part in normalized.split("x", 1)]
+        except Exception:
+            return "1024x1024"
+
+        if width == height:
+            return "1024x1024"
+        return "1024x1792" if height > width else "1792x1024"
+
+    def generate_image(
+        self,
+        prompt: str,
+        session_id: str,
+        model: str = "agnes-image-2.1-flash",
+        size: str = "1024x1024",
+        image_paths: Optional[list[str]] = None,
+        save_dir: Optional[str] = None,
+        n: int = 1,
+        **kwargs,
+    ) -> list[str]:
+        """Generate images and return local file paths."""
+        if not self.api_key:
+            raise RuntimeError("AGNES_API_KEY not set.")
+
+        image_urls = [self._image_to_url(path) for path in (image_paths or [])]
+        selected_model = model or ("agnes-image-2.0-flash" if image_urls else "agnes-image-2.1-flash")
+        payload: dict = {
+            "model": selected_model,
+            "prompt": prompt,
+            "size": self._normalize_size(size),
+            "n": max(1, int(n)),
+        }
+        if image_urls:
+            payload["tags"] = ["img2img"]
+            payload["extra_body"] = {
+                "image": image_urls,
+                "response_format": "url",
+            }
+        elif kwargs.get("response_format"):
+            payload["response_format"] = kwargs["response_format"]
+
+        logger.info(
+            f"AgnesImageClient: 提交图片任务 model={selected_model}, "
+            f"size={payload['size']}, refs={len(image_urls)}"
+        )
+        resp = requests.post(
+            f"{self.base_url}/images/generations",
+            headers=self._headers(),
+            json=payload,
+            timeout=self.timeout,
+            proxies=self._proxies(),
+        )
+        if not resp.ok:
+            logger.error(f"Agnes 图片生成失败: HTTP {resp.status_code}, 响应: {resp.text}")
+            resp.raise_for_status()
+
+        data = resp.json()
+        return self._save_response_images(data, save_dir, session_id)
+
+    def _save_response_images(self, data: dict, save_dir: Optional[str], session_id: str) -> list[str]:
+        items = data.get("data")
+        if not isinstance(items, list) or not items:
+            raise RuntimeError(f"Agnes 图片 API 未返回图片数据: {data}")
+
+        target_dir = save_dir or os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "code",
+            "result",
+            "image",
+            str(session_id),
+        )
+        os.makedirs(target_dir, exist_ok=True)
+
+        paths = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            path = self._save_one_image(item, target_dir)
+            if path:
+                paths.append(path)
+
+        if not paths:
+            raise RuntimeError(f"Agnes 图片 API 响应中未找到 url 或 b64_json: {data}")
+        return paths
+
+    def _save_one_image(self, item: dict, save_dir: str) -> Optional[str]:
+        image_url = item.get("url")
+        if isinstance(image_url, str) and image_url.startswith(("http://", "https://")):
+            return image_url
+
+        file_path = os.path.join(save_dir, f"agnes_{int(time.time())}_{uuid.uuid4().hex[:6]}.png")
+        if item.get("b64_json"):
+            with open(file_path, "wb") as f:
+                f.write(base64.b64decode(item["b64_json"]))
+            return file_path
+
+        return None

--- a/pixelle_video/services/api_services/image_client.py
+++ b/pixelle_video/services/api_services/image_client.py
@@ -1,20 +1,21 @@
-import os
-import time
-import uuid
 import logging
+import os
 from typing import List, Optional
+
 from .config import Config
 
 try:
+    from .image_agnes import AgnesImageClient
     from .image_dashscope import DashScopeClient
-    from .image_seedream import SeedreamClient
     from .image_gpt import ImageGPT
     from .image_processor import ImageProcessor
+    from .image_seedream import SeedreamClient
 except ImportError:
+    from .image_agnes import AgnesImageClient
     from .image_dashscope import DashScopeClient
-    from .image_seedream import SeedreamClient
     from .image_gpt import ImageGPT
     from .image_processor import ImageProcessor
+    from .image_seedream import SeedreamClient
 
 class ImageClient:
     def __init__(self,
@@ -26,7 +27,10 @@ class ImageClient:
                  local_proxy: Optional[str] = None,
                  ark_api_key: Optional[str] = None,
                  ark_base_url: Optional[str] = None,
-                 ark_local_proxy: Optional[str] = None):
+                 ark_local_proxy: Optional[str] = None,
+                 agnes_api_key: Optional[str] = None,
+                 agnes_base_url: Optional[str] = None,
+                 agnes_local_proxy: Optional[str] = None):
         """
         Unified Image Generation Client
         Routes requests to DashScope, Seedream, or GPT based on model name.
@@ -43,9 +47,14 @@ class ImageClient:
         self._ark_base_url = ark_base_url or Config.ARK_BASE_URL
         self._ark_local_proxy = ark_local_proxy
 
+        self._agnes_api_key = agnes_api_key or Config.AGNES_API_KEY
+        self._agnes_base_url = agnes_base_url or Config.AGNES_BASE_URL
+        self._agnes_local_proxy = agnes_local_proxy
+
         self._dashscope_client = None
         self._seedream_client = None
         self._gpt_client = None
+        self._agnes_client = None
 
         # Initialize Image Processor for downloads
         self.image_processor = ImageProcessor()
@@ -89,6 +98,19 @@ class ImageClient:
                 local_proxy=self._gpt_local_proxy,
             )
         return self._gpt_client
+
+    @property
+    def agnes_client(self):
+        """Create Agnes image client only when an Agnes image model is selected."""
+        if not self._agnes_api_key:
+            raise RuntimeError("AGNES_API_KEY not set. Configure Agnes only when using Agnes image models.")
+        if self._agnes_client is None:
+            self._agnes_client = AgnesImageClient(
+                api_key=self._agnes_api_key,
+                base_url=self._agnes_base_url,
+                local_proxy=self._agnes_local_proxy,
+            )
+        return self._agnes_client
 
     def generate_image(self,
                        prompt: str,
@@ -160,7 +182,7 @@ class ImageClient:
                 print(f"Refs: {len(image_paths)}")
                 for p in image_paths:
                     if str(p).startswith("data:"):
-                        print(f" - [Base64图片]")
+                        print(" - [Base64图片]")
                     else:
                         print(f" - {p}")
             print(f"Model: {model}")
@@ -174,6 +196,7 @@ class ImageClient:
         # Determine backend provider
         is_seedream = "seedream" in model.lower()
         is_sora = "sora" in model.lower() or "gpt" in model.lower()
+        is_agnes = "agnes-image" in model.lower()
         
         # Prepare save directory
         if not save_dir:
@@ -185,7 +208,31 @@ class ImageClient:
         
         generated_local_paths = []
 
-        if is_seedream:
+        if is_agnes:
+            try:
+                logging.info(f"ImageClient requesting Agnes: {model}")
+                agnes_size = size.replace("*", "x") if size else "1024x1024"
+                agnes_model = model
+                if image_paths and "2.1" in agnes_model:
+                    logging.info("Agnes image-to-image is optimized for 2.0 Flash; switching model.")
+                    agnes_model = "agnes-image-2.0-flash"
+
+                paths = self.agnes_client.generate_image(
+                    prompt=prompt,
+                    model=agnes_model,
+                    session_id=session_id or "default",
+                    size=agnes_size,
+                    image_paths=image_paths,
+                    save_dir=save_dir,
+                )
+                if paths:
+                    generated_local_paths.extend(paths)
+
+            except Exception as e:
+                logging.error(f"Agnes image generation failed: {e}")
+                raise RuntimeError(f"Agnes image generation failed: {e}") from e
+
+        elif is_seedream:
             # --- Seedream Logic ---
             try:
                 logging.info(f"ImageClient requesting Seedream: {model}")

--- a/pixelle_video/services/api_services/video_agnes.py
+++ b/pixelle_video/services/api_services/video_agnes.py
@@ -1,0 +1,279 @@
+"""
+Agnes Video V2.0 API client.
+
+Implements the OpenAI-compatible Agnes video flow:
+POST /v1/videos -> GET /v1/videos/{task_id} -> download result.
+"""
+
+import os
+import time
+from typing import Optional
+
+import requests
+from loguru import logger
+
+AGNES_BASE_URL = "https://apihub.agnes-ai.com/v1"
+
+
+def _proxy_dict(local_proxy: Optional[str]) -> Optional[dict]:
+    if not local_proxy:
+        return None
+    return {"http": local_proxy, "https": local_proxy}
+
+
+class AgnesVideoClient:
+    """Agnes Video V2.0 asynchronous video generation client."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        local_proxy: Optional[str] = None,
+        timeout: int = 120,
+        poll_interval: int = 5,
+        max_polls: int = 180,
+    ) -> None:
+        self.api_key = api_key or os.getenv("AGNES_API_KEY", "")
+        self.base_url = (base_url or os.getenv("AGNES_BASE_URL") or AGNES_BASE_URL).rstrip("/")
+        self.local_proxy = local_proxy
+        self.timeout = timeout
+        self.poll_interval = poll_interval
+        self.max_polls = max_polls
+
+        if not self.api_key:
+            logger.warning("AgnesVideoClient: AGNES_API_KEY 未设置")
+
+    def _headers(self) -> dict:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _proxies(self) -> Optional[dict]:
+        return _proxy_dict(self.local_proxy)
+
+    @staticmethod
+    def _image_url(image_path: str) -> str:
+        if image_path.startswith(("http://", "https://")):
+            return image_path
+        if image_path.startswith("data:"):
+            raise ValueError("Agnes Video requires a public image URL; data URLs are not supported.")
+        if os.path.exists(image_path):
+            raise ValueError("Agnes Video requires a public image URL; local image files are not supported.")
+        raise FileNotFoundError(f"输入图片不存在: {image_path}")
+
+    @staticmethod
+    def _num_frames(duration: int, frame_rate: int) -> int:
+        target_frames = max(1, int(round(float(duration) * float(frame_rate))))
+        normalized = 8 * max(0, round((target_frames - 1) / 8)) + 1
+        return min(max(normalized, 1), 441)
+
+    @staticmethod
+    def _dimensions(video_ratio: str, resolution: Optional[str]) -> tuple[int, int]:
+        high_res = str(resolution or "").lower() == "1080p"
+        if high_res:
+            sizes = {
+                "16:9": (1920, 1080),
+                "9:16": (1080, 1920),
+                "1:1": (1080, 1080),
+                "4:3": (1440, 1080),
+                "3:4": (1080, 1440),
+                "21:9": (1920, 824),
+            }
+        else:
+            sizes = {
+                "16:9": (1280, 720),
+                "9:16": (720, 1280),
+                "1:1": (1024, 1024),
+                "4:3": (1024, 768),
+                "3:4": (768, 1024),
+                "21:9": (1344, 576),
+            }
+        return sizes.get(video_ratio, sizes["16:9"])
+
+    def generate_video(
+        self,
+        prompt: str,
+        image_path: Optional[str],
+        save_path: str,
+        model: str = "agnes-video-v2.0",
+        duration: int = 5,
+        video_ratio: str = "16:9",
+        resolution: Optional[str] = None,
+        negative_prompt: Optional[str] = None,
+        seed: Optional[int] = None,
+        frame_rate: int = 24,
+        num_inference_steps: Optional[int] = None,
+        mode: Optional[str] = None,
+        **kwargs,
+    ) -> str:
+        """Generate a video, download it to save_path, and return the remote URL."""
+        if not self.api_key:
+            raise RuntimeError("AGNES_API_KEY not set.")
+
+        task_id_or_url = self._submit_task(
+            prompt=prompt,
+            image_path=image_path,
+            model=model,
+            duration=duration,
+            video_ratio=video_ratio,
+            resolution=resolution,
+            negative_prompt=negative_prompt,
+            seed=seed,
+            frame_rate=frame_rate,
+            num_inference_steps=num_inference_steps,
+            mode=mode,
+        )
+
+        video_url = (
+            task_id_or_url
+            if task_id_or_url.startswith(("http://", "https://"))
+            else self._poll_until_done(task_id_or_url, model)
+        )
+        self._download_video(video_url, save_path)
+        return video_url
+
+    def _submit_task(
+        self,
+        prompt: str,
+        image_path: Optional[str],
+        model: str,
+        duration: int,
+        video_ratio: str,
+        resolution: Optional[str],
+        negative_prompt: Optional[str],
+        seed: Optional[int],
+        frame_rate: int,
+        num_inference_steps: Optional[int],
+        mode: Optional[str],
+    ) -> str:
+        width, height = self._dimensions(video_ratio, resolution)
+        num_frames = self._num_frames(duration, frame_rate)
+        payload: dict = {
+            "model": model,
+            "prompt": prompt,
+            "width": width,
+            "height": height,
+            "num_frames": num_frames,
+            "frame_rate": frame_rate,
+        }
+        if mode:
+            payload["mode"] = mode
+        if image_path:
+            payload["image"] = self._image_url(image_path)
+        if negative_prompt:
+            payload["negative_prompt"] = negative_prompt
+        if seed is not None:
+            payload["seed"] = seed
+        if num_inference_steps is not None:
+            payload["num_inference_steps"] = num_inference_steps
+
+        url = f"{self.base_url}/videos"
+        logger.info(
+            f"AgnesVideoClient: 提交任务 model={model}, duration={duration}s, "
+            f"size={width}x{height}, frames={num_frames}, image={bool(image_path)}"
+        )
+        resp = requests.post(
+            url,
+            headers=self._headers(),
+            json=payload,
+            timeout=self.timeout,
+            proxies=self._proxies(),
+        )
+        if not resp.ok:
+            logger.error(f"Agnes 提交失败: HTTP {resp.status_code}, 响应: {resp.text}")
+            resp.raise_for_status()
+
+        data = resp.json()
+        video_url = self._extract_video_url(data)
+        if video_url:
+            return video_url
+
+        task_id = data.get("video_id") or data.get("task_id") or data.get("id")
+        if not task_id:
+            raise RuntimeError(f"Agnes API 未返回任务 ID 或视频 URL: {data}")
+        return str(task_id)
+
+    def _poll_url(self, task_id: str, model: str) -> str:
+        if task_id.startswith("video_"):
+            root_url = self.base_url.removesuffix("/v1")
+            return f"{root_url}/agnesapi?video_id={task_id}&model_name={model}"
+        return f"{self.base_url}/videos/{task_id}"
+
+    def _poll_until_done(self, task_id: str, model: str = "agnes-video-v2.0") -> str:
+        url = self._poll_url(task_id, model)
+        for i in range(self.max_polls):
+            resp = requests.get(
+                url,
+                headers=self._headers(),
+                timeout=30,
+                proxies=self._proxies(),
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            video_url = self._extract_video_url(data)
+            if video_url:
+                return video_url
+
+            status = str(data.get("status") or data.get("task_status") or "").lower()
+            if status in {"succeeded", "succeed", "completed", "complete", "done"}:
+                if task_id.startswith("video_"):
+                    raise RuntimeError(f"Agnes API completed without video URL: {data}")
+                return f"{self.base_url}/videos/{task_id}/content"
+
+            if status in {"failed", "error", "cancelled", "canceled", "expired"}:
+                message = (
+                    data.get("error", {}).get("message")
+                    if isinstance(data.get("error"), dict)
+                    else data.get("error")
+                ) or data.get("message") or data.get("status_msg") or "未知错误"
+                raise RuntimeError(f"Agnes 视频生成失败: {message} (task_id={task_id})")
+
+            logger.debug(
+                f"AgnesVideoClient: 任务进行中 {task_id}, status={status}, poll={i + 1}"
+            )
+            time.sleep(self.poll_interval)
+
+        raise TimeoutError(f"Agnes 视频生成超时 (task_id={task_id})")
+
+    def _extract_video_url(self, data: dict) -> str:
+        candidates = [
+            data.get("url"),
+            data.get("video_url"),
+            data.get("download_url"),
+            data.get("remixed_from_video_id"),
+            data.get("content", {}).get("video_url") if isinstance(data.get("content"), dict) else None,
+            data.get("output", {}).get("video_url") if isinstance(data.get("output"), dict) else None,
+            data.get("output", {}).get("url") if isinstance(data.get("output"), dict) else None,
+        ]
+        data_items = data.get("data")
+        if isinstance(data_items, list):
+            for item in data_items:
+                if isinstance(item, dict):
+                    candidates.extend([item.get("url"), item.get("video_url")])
+        elif isinstance(data_items, dict):
+            candidates.extend([data_items.get("url"), data_items.get("video_url")])
+
+        for value in candidates:
+            if isinstance(value, str) and value.startswith(("http://", "https://")):
+                return value
+        return ""
+
+    def _download_video(self, video_url: str, save_path: str) -> None:
+        save_dir = os.path.dirname(save_path)
+        if save_dir:
+            os.makedirs(save_dir, exist_ok=True)
+        headers = self._headers() if video_url.startswith(self.base_url) else None
+        resp = requests.get(
+            video_url,
+            headers=headers,
+            stream=True,
+            timeout=600,
+            proxies=self._proxies(),
+        )
+        resp.raise_for_status()
+        with open(save_path, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)
+        logger.info(f"AgnesVideoClient: 视频已保存: {save_path}")

--- a/pixelle_video/services/api_services/video_client.py
+++ b/pixelle_video/services/api_services/video_client.py
@@ -3,18 +3,22 @@
 根据 model 名称自动路由到对应后端：
   - wan*      → DashscopeVideoClient (DashScope VideoSynthesis)
   - kling*    → KlingVideoClient (可灵 AI)
+  - agnes*    → AgnesVideoClient
 """
 
-import os
 import logging
+import os
 from typing import Optional
+
 from .config import Config
 
 try:
+    from .video_agnes import AgnesVideoClient
     from .video_dashscope import DashscopeVideoClient
     from .video_kling import KlingVideoClient
     from .video_seedance import SeedanceVideoClient
 except ImportError:
+    from video_agnes import AgnesVideoClient
     from video_dashscope import DashscopeVideoClient
     from video_kling import KlingVideoClient
     from video_seedance import SeedanceVideoClient
@@ -40,6 +44,9 @@ class VideoClient:
         ark_api_key: Optional[str] = None,
         ark_base_url: Optional[str] = None,
         ark_local_proxy: Optional[str] = None,
+        agnes_api_key: Optional[str] = None,
+        agnes_base_url: Optional[str] = None,
+        agnes_local_proxy: Optional[str] = None,
     ):
         self._dashscope_api_key = dashscope_api_key or Config.DASHSCOPE_API_KEY
         self._dashscope_base_url = dashscope_base_url or Config.DASHSCOPE_BASE_URL
@@ -54,9 +61,14 @@ class VideoClient:
         self._ark_base_url = ark_base_url or Config.ARK_BASE_URL or os.getenv("ARK_BASE_URL")
         self._ark_local_proxy = ark_local_proxy
 
+        self._agnes_api_key = agnes_api_key or Config.AGNES_API_KEY or os.getenv("AGNES_API_KEY")
+        self._agnes_base_url = agnes_base_url or Config.AGNES_BASE_URL or os.getenv("AGNES_BASE_URL")
+        self._agnes_local_proxy = agnes_local_proxy
+
         self._dashscope_client = None
         self._kling_client = None
         self._seedance_client = None
+        self._agnes_client = None
 
     @property
     def Dashscope_client(self):
@@ -92,6 +104,17 @@ class VideoClient:
             )
         return self._seedance_client
 
+    @property
+    def agnes_client(self):
+        """Create Agnes client only when an Agnes model is selected."""
+        if self._agnes_client is None:
+            self._agnes_client = AgnesVideoClient(
+                api_key=self._agnes_api_key,
+                base_url=self._agnes_base_url,
+                local_proxy=self._agnes_local_proxy,
+            )
+        return self._agnes_client
+
     def generate_video(
         self,
         prompt: str,
@@ -118,6 +141,8 @@ class VideoClient:
         cfg_scale: float = 0.5,
         generate_audio: Optional[bool] = None,
         audio: Optional[bool] = None,
+        frame_rate: Optional[int] = None,
+        num_inference_steps: Optional[int] = None,
     ) -> str:
         """
         生成视频
@@ -144,7 +169,7 @@ class VideoClient:
             print("---- VIDEO GENERATION REQUEST ----")
             print(f"Prompt: {prompt}")
             if image_path and str(image_path).startswith("data:"):
-                print(f"Image: [Base64图片]")
+                print("Image: [Base64图片]")
             else:
                 print(f"Image: {image_path}")
             print(f"Model: {model}")
@@ -201,6 +226,20 @@ class VideoClient:
                 seed,
                 watermark,
                 generate_audio,
+            )
+        elif "agnes" in model_lower:
+            return self._generate_agnes(
+                prompt,
+                image_path,
+                save_path,
+                model,
+                duration,
+                video_ratio,
+                resolution,
+                seed,
+                negative_prompt,
+                frame_rate,
+                num_inference_steps,
             )
         elif "wan" in model_lower or "happyhorse" in model_lower:
             return self._generate_wan(
@@ -330,4 +369,34 @@ class VideoClient:
             seed=seed,
             watermark=watermark,
             generate_audio=generate_audio,
+        )
+
+    def _generate_agnes(
+        self,
+        prompt: str,
+        image_path: Optional[str],
+        save_path: str,
+        model: str,
+        duration: int = 5,
+        video_ratio: str = "16:9",
+        resolution: Optional[str] = None,
+        seed: Optional[int] = None,
+        negative_prompt: Optional[str] = None,
+        frame_rate: Optional[int] = None,
+        num_inference_steps: Optional[int] = None,
+    ) -> str:
+        """通过 Agnes Video V2.0 生成视频"""
+        logger.info(f"VideoClient: 路由至 Agnes model={model}")
+        return self.agnes_client.generate_video(
+            prompt=prompt,
+            image_path=image_path,
+            save_path=save_path,
+            model=model,
+            duration=duration,
+            video_ratio=video_ratio,
+            resolution=resolution,
+            seed=seed,
+            negative_prompt=negative_prompt,
+            frame_rate=frame_rate or 24,
+            num_inference_steps=num_inference_steps,
         )

--- a/pixelle_video/services/frame_processor.py
+++ b/pixelle_video/services/frame_processor.py
@@ -307,6 +307,8 @@ class FrameProcessor:
             output_path=first_frame_path,
             index=frame.index + 1,
         )
+        if image_result.url.startswith(("http://", "https://")):
+            api_video_params["image_path"] = image_result.url
         frame.image_path = await self._download_media(
             image_result.url,
             frame.index,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "edge-tts==7.2.7",
     "certifi>=2025.10.5",
     "ffmpeg-python>=0.2.0",
-    "httpx>=0.28.1",
+    "httpx[socks]>=0.28.1",
     "pillow>=10.0.0,<12",
     "streamlit>=1.40.0",
     "openai>=2.6.0",

--- a/tests/services/api_services/agnes_image_test.py
+++ b/tests/services/api_services/agnes_image_test.py
@@ -1,0 +1,119 @@
+from pixelle_video.services.api_services import image_agnes
+from pixelle_video.services.api_services.image_agnes import AgnesImageClient
+from pixelle_video.services.api_services.image_client import ImageClient
+
+
+class DummyResponse:
+    def __init__(self, data=None, content=b"image", ok=True, status_code=200):
+        self._data = data or {}
+        self._content = content
+        self.ok = ok
+        self.status_code = status_code
+        self.text = str(self._data)
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        if not self.ok:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def iter_content(self, chunk_size=8192):
+        yield self._content
+
+
+def test_generate_text_to_image_builds_agnes_payload(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_post(url, headers, json, timeout, proxies):
+        captured.update({"url": url, "headers": headers, "json": json, "proxies": proxies})
+        return DummyResponse({"data": [{"url": "https://cdn.example/image.png"}]})
+
+    monkeypatch.setattr(image_agnes.requests, "post", fake_post)
+
+    client = AgnesImageClient(
+        api_key="key",
+        base_url="https://apihub.agnes-ai.com/v1",
+        local_proxy="http://127.0.0.1:9090",
+    )
+    paths = client.generate_image(
+        prompt="A floating city",
+        session_id="session",
+        model="agnes-image-2.1-flash",
+        size="1792x1024",
+        save_dir=str(tmp_path),
+    )
+
+    assert paths == ["https://cdn.example/image.png"]
+    assert captured["url"] == "https://apihub.agnes-ai.com/v1/images/generations"
+    assert captured["headers"]["Authorization"] == "Bearer key"
+    assert captured["proxies"] == {
+        "http": "http://127.0.0.1:9090",
+        "https": "http://127.0.0.1:9090",
+    }
+    assert captured["json"] == {
+        "model": "agnes-image-2.1-flash",
+        "prompt": "A floating city",
+        "size": "1792x1024",
+        "n": 1,
+    }
+
+
+def test_generate_image_to_image_builds_extra_body(monkeypatch, tmp_path):
+    image_path = tmp_path / "input.jpg"
+    image_path.write_bytes(b"jpg")
+    captured = {}
+
+    def fake_post(url, headers, json, timeout, proxies):
+        captured.update({"json": json})
+        return DummyResponse({"data": [{"b64_json": "cG5nLWJ5dGVz"}]})
+
+    monkeypatch.setattr(image_agnes.requests, "post", fake_post)
+
+    client = AgnesImageClient(api_key="key")
+    paths = client.generate_image(
+        prompt="Make it neon",
+        session_id="session",
+        model="agnes-image-2.0-flash",
+        size="1920*1080",
+        image_paths=[str(image_path)],
+        save_dir=str(tmp_path),
+    )
+
+    assert len(paths) == 1
+    assert captured["json"]["model"] == "agnes-image-2.0-flash"
+    assert captured["json"]["size"] == "1792x1024"
+    assert captured["json"]["tags"] == ["img2img"]
+    assert captured["json"]["extra_body"]["response_format"] == "url"
+    assert captured["json"]["extra_body"]["image"][0].startswith("data:image/jpeg;base64,")
+
+
+def test_image_client_routes_agnes_models(monkeypatch, tmp_path):
+    captured = {}
+
+    class FakeAgnesClient:
+        def generate_image(self, **kwargs):
+            captured.update(kwargs)
+            output = tmp_path / "result.png"
+            output.write_bytes(b"png")
+            return [str(output)]
+
+    client = ImageClient(agnes_api_key="key", agnes_base_url="https://apihub.agnes-ai.com/v1")
+    client._agnes_client = FakeAgnesClient()
+
+    paths = client.generate_image(
+        prompt="A clean poster",
+        model="agnes-image-2.1-flash",
+        save_dir=str(tmp_path),
+        session_id="sid",
+        video_ratio="16:9",
+        resolution="1080P",
+    )
+
+    assert paths == [str(tmp_path / "result.png")]
+    assert captured["prompt"] == "A clean poster"
+    assert captured["model"] == "agnes-image-2.1-flash"
+    assert captured["session_id"] == "sid"
+    assert captured["size"] == "1920x1080"
+    assert captured["image_paths"] is None
+    assert captured["save_dir"] == str(tmp_path)

--- a/tests/services/api_services/agnes_video_test.py
+++ b/tests/services/api_services/agnes_video_test.py
@@ -1,0 +1,212 @@
+from pixelle_video.services.api_services import video_agnes
+from pixelle_video.services.api_services.video_agnes import AgnesVideoClient
+
+
+class DummyResponse:
+    def __init__(self, data=None, content=b"video", ok=True, status_code=200):
+        self._data = data or {}
+        self._content = content
+        self.ok = ok
+        self.status_code = status_code
+        self.text = str(self._data)
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        if not self.ok:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def iter_content(self, chunk_size=8192):
+        yield self._content
+
+
+def test_submit_task_builds_agnes_payload(monkeypatch):
+    captured = {}
+
+    def fake_post(url, headers, json, timeout, proxies):
+        captured.update(
+            {
+                "url": url,
+                "headers": headers,
+                "json": json,
+                "timeout": timeout,
+                "proxies": proxies,
+            }
+        )
+        return DummyResponse({"id": "task_123", "status": "queued"})
+
+    monkeypatch.setattr(video_agnes.requests, "post", fake_post)
+
+    client = AgnesVideoClient(
+        api_key="key",
+        base_url="https://apihub.agnes-ai.com/v1",
+        local_proxy="http://127.0.0.1:9090",
+    )
+    task_id = client._submit_task(
+        prompt="A calm cinematic shot",
+        image_path="https://cdn.example/frame.png",
+        model="agnes-video-v2.0",
+        duration=5,
+        video_ratio="9:16",
+        resolution="720P",
+        negative_prompt="blur",
+        seed=7,
+        frame_rate=24,
+        num_inference_steps=32,
+        mode=None,
+    )
+
+    assert task_id == "task_123"
+    assert captured["url"] == "https://apihub.agnes-ai.com/v1/videos"
+    assert captured["headers"]["Authorization"] == "Bearer key"
+    assert captured["proxies"] == {
+        "http": "http://127.0.0.1:9090",
+        "https": "http://127.0.0.1:9090",
+    }
+    payload = captured["json"]
+    assert payload["model"] == "agnes-video-v2.0"
+    assert payload["prompt"] == "A calm cinematic shot"
+    assert "mode" not in payload
+    assert payload["width"] == 720
+    assert payload["height"] == 1280
+    assert payload["num_frames"] == 121
+    assert payload["frame_rate"] == 24
+    assert payload["negative_prompt"] == "blur"
+    assert payload["seed"] == 7
+    assert payload["num_inference_steps"] == 32
+    assert payload["image"] == "https://cdn.example/frame.png"
+
+
+def test_submit_task_rejects_local_image(monkeypatch, tmp_path):
+    image_path = tmp_path / "frame.png"
+    image_path.write_bytes(b"png")
+
+    client = AgnesVideoClient(api_key="key")
+
+    try:
+        client._submit_task(
+            prompt="A calm cinematic shot",
+            image_path=str(image_path),
+            model="agnes-video-v2.0",
+            duration=5,
+            video_ratio="9:16",
+            resolution="720P",
+            negative_prompt=None,
+            seed=None,
+            frame_rate=24,
+            num_inference_steps=None,
+            mode=None,
+        )
+    except ValueError as exc:
+        assert "public image URL" in str(exc)
+    else:
+        raise AssertionError("Expected local Agnes video image input to be rejected")
+
+
+def test_generate_video_polls_and_downloads(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_post(url, headers, json, timeout, proxies):
+        return DummyResponse({"task_id": "task_abc", "status": "queued"})
+
+    def fake_get(url, **kwargs):
+        calls.append(url)
+        if url.endswith("/videos/task_abc"):
+            return DummyResponse({"status": "succeeded", "data": {"url": "https://cdn.example/video.mp4"}})
+        return DummyResponse(content=b"mp4-bytes")
+
+    monkeypatch.setattr(video_agnes.requests, "post", fake_post)
+    monkeypatch.setattr(video_agnes.requests, "get", fake_get)
+
+    output_path = tmp_path / "out.mp4"
+    client = AgnesVideoClient(
+        api_key="key",
+        base_url="https://apihub.agnes-ai.com/v1",
+        poll_interval=0,
+    )
+    video_url = client.generate_video(
+        prompt="A short scene",
+        image_path=None,
+        save_path=str(output_path),
+        model="agnes-video-v2.0",
+        duration=3,
+    )
+
+    assert video_url == "https://cdn.example/video.mp4"
+    assert output_path.read_bytes() == b"mp4-bytes"
+    assert calls == ["https://apihub.agnes-ai.com/v1/videos/task_abc", "https://cdn.example/video.mp4"]
+
+
+def test_generate_video_uses_content_endpoint_when_status_has_no_url(monkeypatch, tmp_path):
+    captured_download_headers = {}
+
+    def fake_post(url, headers, json, timeout, proxies):
+        return DummyResponse({"task_id": "task_content", "status": "queued"})
+
+    def fake_get(url, **kwargs):
+        if url.endswith("/videos/task_content"):
+            return DummyResponse({"status": "succeeded"})
+        captured_download_headers.update(kwargs.get("headers") or {})
+        return DummyResponse(content=b"content-bytes")
+
+    monkeypatch.setattr(video_agnes.requests, "post", fake_post)
+    monkeypatch.setattr(video_agnes.requests, "get", fake_get)
+
+    output_path = tmp_path / "content.mp4"
+    client = AgnesVideoClient(
+        api_key="key",
+        base_url="https://apihub.agnes-ai.com/v1",
+        poll_interval=0,
+    )
+    video_url = client.generate_video(
+        prompt="A short scene",
+        image_path=None,
+        save_path=str(output_path),
+        model="agnes-video-v2.0",
+        duration=3,
+    )
+
+    assert video_url == "https://apihub.agnes-ai.com/v1/videos/task_content/content"
+    assert output_path.read_bytes() == b"content-bytes"
+    assert captured_download_headers["Authorization"] == "Bearer key"
+
+
+def test_extract_video_url_accepts_common_response_shapes():
+    client = AgnesVideoClient(api_key="key")
+
+    assert client._extract_video_url({"url": "https://cdn.example/a.mp4"}).endswith("a.mp4")
+    assert client._extract_video_url({"remixed_from_video_id": "https://cdn.example/r.mp4"}).endswith(
+        "r.mp4"
+    )
+    assert client._extract_video_url({"data": [{"url": "https://cdn.example/b.mp4"}]}).endswith(
+        "b.mp4"
+    )
+    assert client._extract_video_url({"output": {"video_url": "https://cdn.example/c.mp4"}}).endswith(
+        "c.mp4"
+    )
+
+
+def test_poll_uses_recommended_video_id_endpoint(monkeypatch):
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append(url)
+        return DummyResponse(
+            {
+                "status": "completed",
+                "remixed_from_video_id": "https://cdn.example/final.mp4",
+            }
+        )
+
+    monkeypatch.setattr(video_agnes.requests, "get", fake_get)
+
+    client = AgnesVideoClient(api_key="key", base_url="https://apihub.agnes-ai.com/v1")
+
+    assert (
+        client._poll_until_done("video_123", "agnes-video-v2.0")
+        == "https://cdn.example/final.mp4"
+    )
+    assert calls == [
+        "https://apihub.agnes-ai.com/agnesapi?video_id=video_123&model_name=agnes-video-v2.0"
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -992,6 +992,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
+]
+
 [[package]]
 name = "httpx-sse"
 version = "0.4.3"
@@ -1972,7 +1977,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "ffmpeg-python" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["socks"] },
     { name = "loguru" },
     { name = "moviepy" },
     { name = "numpy" },
@@ -2005,7 +2010,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastmcp", specifier = ">=2.0.0" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx", extras = ["socks"], specifier = ">=0.28.1" },
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "moviepy", specifier = "==1.0.3" },
     { name = "numpy", specifier = ">=1.26.0" },
@@ -2916,6 +2921,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]

--- a/web/components/settings.py
+++ b/web/components/settings.py
@@ -16,9 +16,9 @@ System settings component for web UI
 
 import streamlit as st
 
-from web.i18n import tr, get_language
-from web.utils.streamlit_helpers import safe_rerun
 from pixelle_video.config import config_manager
+from web.i18n import get_language, tr
+from web.utils.streamlit_helpers import safe_rerun
 
 
 def render_advanced_settings():
@@ -39,7 +39,11 @@ def render_advanced_settings():
                 st.markdown(f"**{tr('settings.llm.title')}**")
                 
                 # Quick preset selection
-                from pixelle_video.llm_presets import get_preset_names, get_preset, find_preset_by_base_url_and_model
+                from pixelle_video.llm_presets import (
+                    find_preset_by_base_url_and_model,
+                    get_preset,
+                    get_preset_names,
+                )
                 
                 # Custom at the end
                 preset_names = get_preset_names() + ["Custom"]
@@ -299,11 +303,13 @@ def render_advanced_settings():
         openai_cfg = api_cfg.get("openai", {})
         dashscope_cfg = api_cfg.get("dashscope", {})
         ark_cfg = api_cfg.get("ark", {})
+        agnes_cfg = api_cfg.get("agnes", {})
         kling_cfg = api_cfg.get("kling", {})
         default_api_base_urls = {
             "openai": "https://api.openai.com/v1",
             "dashscope": "https://dashscope.aliyuncs.com/api/v1",
             "ark": "https://ark.cn-beijing.volces.com/api/v3",
+            "agnes": "https://apihub.agnes-ai.com/v1",
             "kling": "https://api-beijing.klingai.com",
         }
 
@@ -402,6 +408,25 @@ def render_advanced_settings():
                     key="api_media_ark_base_url",
                 )
 
+                st.markdown("**Agnes AI / Video V2.0**")
+                api_agnes_use_proxy = st.checkbox(
+                    "Agnes 启用代理" if zh else "Use proxy for Agnes",
+                    value=bool(agnes_cfg.get("use_proxy", False)),
+                    key="api_media_agnes_use_proxy",
+                )
+                api_agnes_key = st.text_input(
+                    "Agnes API Key",
+                    value=agnes_cfg.get("api_key", ""),
+                    type="password",
+                    key="api_media_agnes_key",
+                )
+                api_agnes_base_url = st.text_input(
+                    "Agnes Base URL",
+                    value=agnes_cfg.get("base_url") or default_api_base_urls["agnes"],
+                    placeholder="https://apihub.agnes-ai.com/v1",
+                    key="api_media_agnes_base_url",
+                )
+
                 st.markdown("**Kling AI / 可灵**")
                 api_kling_use_proxy = st.checkbox(
                     "Kling 启用代理" if zh else "Use proxy for Kling",
@@ -472,6 +497,11 @@ def render_advanced_settings():
                         "api_key": api_ark_key or "",
                         "base_url": api_ark_base_url or "",
                         "use_proxy": bool(api_ark_use_proxy),
+                    })
+                    config_manager.set_api_provider_config("agnes", {
+                        "api_key": api_agnes_key or "",
+                        "base_url": api_agnes_base_url or "",
+                        "use_proxy": bool(api_agnes_use_proxy),
                     })
                     config_manager.set_api_provider_config("kling", {
                         "base_url": api_kling_base_url or "",


### PR DESCRIPTION
## Summary

- Add Agnes image generation client
- Add Agnes video generation client
- Add Agnes provider settings in Web UI
- Add Agnes LLM presets
- Add SOCKS proxy support via httpx[socks]
- Normalize Agnes video num_frames to the required 8n + 1 rule
- Prefer Agnes video_id result polling endpoint
- Preserve remote Agnes image URLs for image-to-video workflows
- Add Agnes image/video client tests

## Verification

- uv run --extra dev pytest
- uv run python -m compileall pixelle_video web tests
- uv run --extra dev ruff check pixelle_video/services/api_services/image_agnes.py pixelle_video/services/api_services/video_agnes.py tests/services/api_services/agnes_image_test.py tests/services/api_services/agnes_video_test.py