### PR TITLE
feat: add TwelveLabs Pegasus as a video asset-analysis provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ uv run streamlit run web/app.py
 - **LLM 配置**: 选择 AI 模型（如通义千问、GPT 等）并填入 API Key
 - **ComfyUI / RunningHub 配置**: 如需使用工作流生成图片、视频或语音，配置本地 ComfyUI 地址或 RunningHub API Key
 - **API 媒体模型配置**: 如需直连图像/视频模型，配置 DashScope、OpenAI、ARK、Kling 等供应商的 API Key、Base URL 和代理选项
+- **TwelveLabs（可选）**: 配置 `twelvelabs` API Key 后，可使用 [Pegasus](https://docs.twelvelabs.io) 视频理解模型分析上传的视频素材。Pegasus 是视频原生模型，会理解整段视频（运动、场景切换、动作），而非仅采样若干帧；在素材分析服务中作为「仅视频」选项出现。可在 [twelvelabs.io](https://twelvelabs.io) 免费获取 API Key（提供慷慨的免费额度）。
 
 配置好后点击「保存配置」，就可以开始生成视频了！
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -247,6 +247,7 @@ On first use, expand the "⚙️ System Configuration" panel and fill in:
 - **LLM Configuration**: Select AI model (such as Qwen, GPT, etc.) and enter API Key
 - **ComfyUI / RunningHub Configuration**: Configure local ComfyUI or RunningHub API Key if you want to use workflow-based image, video, or voice generation
 - **API Media Model Configuration**: Configure API Key, Base URL, and proxy options for direct image/video model providers such as DashScope, OpenAI, ARK, and Kling
+- **TwelveLabs (optional)**: Add a `twelvelabs` API key to analyze uploaded video footage with [Pegasus](https://docs.twelvelabs.io) — a video-native model that reasons over the whole clip (motion, scene changes, action) instead of a few sampled frames. It appears as a video-only option in the asset-analysis service. Get a free API key at [twelvelabs.io](https://twelvelabs.io) (generous free tier).
 
 After configuration, click "Save Configuration", and you can start generating videos!
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -35,6 +35,12 @@ api_providers:
     api_key: ""
     base_url: "https://ark.cn-beijing.volces.com/api/v3"
     use_proxy: false
+  # TwelveLabs: Pegasus video-understanding for asset analysis (video-only).
+  # Get a free API key at https://twelvelabs.io (generous free tier).
+  twelvelabs:
+    api_key: ""
+    base_url: "https://api.twelvelabs.io/v1.3"
+    use_proxy: false
   kling:
     base_url: "https://api-beijing.klingai.com"
     access_key: ""

--- a/pixelle_video/config/schema.py
+++ b/pixelle_video/config/schema.py
@@ -55,6 +55,7 @@ class APIProvidersConfig(BaseModel):
     deepseek: APIKeyProviderConfig = Field(default_factory=APIKeyProviderConfig)
     gemini: APIKeyProviderConfig = Field(default_factory=APIKeyProviderConfig)
     ark: APIKeyProviderConfig = Field(default_factory=APIKeyProviderConfig)
+    twelvelabs: APIKeyProviderConfig = Field(default_factory=APIKeyProviderConfig)
     kling: AccessSecretProviderConfig = Field(default_factory=AccessSecretProviderConfig)
 
 

--- a/pixelle_video/services/api_asset_analysis.py
+++ b/pixelle_video/services/api_asset_analysis.py
@@ -32,11 +32,22 @@ class APIAssetAnalysisService:
             "qwen3.6-flash",
             "qwen3.5-omni-plus",
         ],
+        # TwelveLabs Pegasus is a video-native understanding model: it reasons
+        # over the whole clip (motion, scene changes, action) rather than a few
+        # sampled frames, so it only handles video assets — not images.
+        "twelvelabs": [
+            "pegasus1.5",
+            "pegasus1.2",
+        ],
     }
 
     VLM_PROVIDER_LABELS = {
         "dashscope": "DashScope",
+        "twelvelabs": "TwelveLabs",
     }
+
+    # Providers whose models can only analyze video assets (not images).
+    VIDEO_ONLY_PROVIDERS = {"twelvelabs"}
 
     IMAGE_PROMPT = """请分析这张素材图片，用中文给出适合短视频脚本创作的简洁描述。
 
@@ -71,6 +82,8 @@ class APIAssetAnalysisService:
                 continue
 
             provider_label = self.VLM_PROVIDER_LABELS.get(provider, provider.title())
+            video_only = provider in self.VIDEO_ONLY_PROVIDERS
+            supported_assets = ["video"] if video_only else ["image", "video"]
             for model in provider_models:
                 key = f"api/vlm/{provider}/{model}"
                 models.append({
@@ -83,6 +96,7 @@ class APIAssetAnalysisService:
                     "media_type": "asset_analysis",
                     "ability_type": "vlm_asset_analysis",
                     "ability_types": ["vlm_asset_analysis"],
+                    "supported_assets": supported_assets,
                 })
 
         return models
@@ -97,6 +111,12 @@ class APIAssetAnalysisService:
         image_file = Path(image_path)
         if not image_file.exists():
             raise FileNotFoundError(f"Image file not found: {image_path}")
+
+        if self._provider_of(model) in self.VIDEO_ONLY_PROVIDERS:
+            raise ValueError(
+                f"Model '{model}' is video-only and cannot analyze images. "
+                "Select a vision model that supports images for image assets."
+            )
 
         return await self._query_vlm(
             prompt=prompt or self.IMAGE_PROMPT,
@@ -154,10 +174,12 @@ class APIAssetAnalysisService:
 
         providers = self.config.get("api_providers", {}) or {}
         dashscope = providers.get("dashscope", {}) or {}
+        twelvelabs = providers.get("twelvelabs", {}) or {}
 
         client = VLM(
             dashscope_api_key=dashscope.get("api_key"),
             dashscope_base_url=dashscope.get("base_url"),
+            twelvelabs_api_key=twelvelabs.get("api_key"),
         )
         result = await asyncio.to_thread(
             client.query,
@@ -171,6 +193,14 @@ class APIAssetAnalysisService:
         if not description:
             raise RuntimeError("API VLM analysis returned empty description")
         return description
+
+    def _provider_of(self, model: Optional[str]) -> Optional[str]:
+        """Resolve which provider a bare model name belongs to."""
+        name = (model or "").strip()
+        for provider, provider_models in self.VLM_MODELS.items():
+            if name in provider_models:
+                return provider
+        return None
 
     def _get_asset_type(self, path: Path) -> str:
         image_exts = {".jpg", ".jpeg", ".png", ".gif", ".webp"}

--- a/pixelle_video/services/api_services/config.py
+++ b/pixelle_video/services/api_services/config.py
@@ -34,6 +34,7 @@ class _ConfigMeta(type):
             "GOOGLE_GEMINI_BASE_URL": ("gemini", "base_url", ""),
             "ARK_API_KEY": ("ark", "api_key", ""),
             "ARK_BASE_URL": ("ark", "base_url", ""),
+            "TWELVELABS_API_KEY": ("twelvelabs", "api_key", ""),
             "KLING_BASE_URL": ("kling", "base_url", ""),
             "KLING_ACCESS_KEY": ("kling", "access_key", ""),
             "KLING_SECRET_KEY": ("kling", "secret_key", ""),

--- a/pixelle_video/services/api_services/vlm_client.py
+++ b/pixelle_video/services/api_services/vlm_client.py
@@ -4,18 +4,28 @@ from .config import Config
 
 try:
     from .vlm_dashscope import QwenVLClient
+    from .vlm_twelvelabs import PegasusClient
 except ImportError:
     from vlm_dashscope import QwenVLClient
+    from vlm_twelvelabs import PegasusClient
+
+# Pegasus is video-only; models are routed to TwelveLabs by name prefix.
+_TWELVELABS_MODEL_PREFIX = "pegasus"
 
 class VLM:
     def __init__(self,
                  dashscope_api_key: Optional[str] = None,
-                 dashscope_base_url: Optional[str] = None):
+                 dashscope_base_url: Optional[str] = None,
+                 twelvelabs_api_key: Optional[str] = None):
         """
-        Unified VLM (Vision Language Model) Client
-        Routes asset-analysis VLM requests to DashScope (Qwen/Qwen-Omni).
+        Unified VLM (Vision Language Model) Client.
+
+        Routes asset-analysis VLM requests by model name:
+        - ``pegasus*`` -> TwelveLabs Pegasus (video-only understanding)
+        - everything else -> DashScope (Qwen/Qwen-Omni)
         """
         dashscope_key = dashscope_api_key or Config.DASHSCOPE_API_KEY
+        twelvelabs_key = twelvelabs_api_key or Config.TWELVELABS_API_KEY
 
         self.dashscope_client = (
             QwenVLClient(
@@ -23,6 +33,9 @@ class VLM:
                 base_url=dashscope_base_url or Config.DASHSCOPE_BASE_URL
             )
             if dashscope_key else None
+        )
+        self.twelvelabs_client = (
+            PegasusClient(api_key=twelvelabs_key) if twelvelabs_key else None
         )
 
     def query(self,
@@ -53,6 +66,22 @@ class VLM:
             if session_id:
                 print(f"Session ID: {session_id}")
             print("-" * 30)
+
+        # Route Pegasus (video understanding) to TwelveLabs.
+        if selected_model.lower().startswith(_TWELVELABS_MODEL_PREFIX):
+            if self.twelvelabs_client is None:
+                raise RuntimeError("TwelveLabs VLM API key is not configured.")
+            if image_paths and not video_paths:
+                raise ValueError(
+                    "TwelveLabs Pegasus is video-only and cannot analyze images."
+                )
+            if not video_paths:
+                raise ValueError("TwelveLabs Pegasus requires a video input.")
+            return self.twelvelabs_client.analyze_video(
+                text=prompt,
+                videos=video_paths,
+                model=selected_model,
+            )
 
         if self.dashscope_client is None:
             raise RuntimeError("DashScope VLM API key is not configured.")

--- a/pixelle_video/services/api_services/vlm_twelvelabs.py
+++ b/pixelle_video/services/api_services/vlm_twelvelabs.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""
+TwelveLabs Pegasus video-understanding API client.
+
+Pegasus is a video-native model: it reasons over the full clip (motion, scene
+changes, on-screen action) rather than a handful of sampled frames, which makes
+it a strong fit for analysing uploaded footage before script/storyboard
+generation in Pixelle-Video.
+
+Notes / gotchas (verified against the official `twelvelabs` SDK, >=1.2.8):
+- Pegasus does NOT accept a bare ``video_id`` here; it needs a public URL
+  (``VideoContext_Url``) or an uploaded asset (``VideoContext_AssetId``).
+- Local files are uploaded as a TwelveLabs asset first via
+  ``assets.create(method="direct", ...)``. Direct upload is capped at 200MB;
+  larger footage should be passed as a public URL (up to 4GB).
+- The analysed window must be at least 4 seconds long.
+
+Docs: https://docs.twelvelabs.io
+"""
+
+import os
+import time
+from typing import List, Optional
+
+try:
+    from twelvelabs import TwelveLabs
+    from twelvelabs.types import VideoContext_AssetId, VideoContext_Url
+except ImportError:  # pragma: no cover - exercised only when SDK is absent
+    TwelveLabs = None
+    VideoContext_Url = None
+    VideoContext_AssetId = None
+
+# Direct asset upload limit (bytes). Above this, callers must use a public URL.
+DIRECT_UPLOAD_MAX_BYTES = 200 * 1024 * 1024
+
+# Poll budget for an uploaded asset to become ready before analysis.
+_ASSET_READY_TIMEOUT_SEC = 120
+_ASSET_POLL_INTERVAL_SEC = 3
+
+# Pegasus requires max_tokens >= 512.
+_MIN_MAX_TOKENS = 512
+
+
+class PegasusClient:
+    """TwelveLabs Pegasus client for video-only asset analysis."""
+
+    def __init__(self, api_key: Optional[str] = None):
+        """
+        :param api_key: TwelveLabs API key. Falls back to TWELVELABS_API_KEY env var.
+        """
+        self.api_key = api_key or os.getenv("TWELVELABS_API_KEY")
+
+    def analyze_video(
+        self,
+        text: str,
+        videos: List[str],
+        model: str,
+        max_tokens: int = 2048,
+        temperature: Optional[float] = None,
+    ) -> str:
+        """
+        Analyze a single video with Pegasus and return the generated text.
+
+        :param text: Analysis prompt.
+        :param videos: List with exactly one video path or URL.
+        :param model: Pegasus model name (e.g. ``pegasus1.5``).
+        :param max_tokens: Max output tokens.
+        :param temperature: Optional sampling temperature.
+        :return: Generated text description.
+        """
+        if TwelveLabs is None:
+            raise RuntimeError(
+                "twelvelabs package not installed. Run: pip install twelvelabs"
+            )
+        if not self.api_key:
+            raise RuntimeError("TwelveLabs API key is not configured.")
+        if not videos:
+            raise ValueError("Pegasus analysis requires a video path or URL.")
+        if len(videos) > 1:
+            raise ValueError("Pegasus analyzes one video at a time.")
+
+        source = videos[0]
+        client = TwelveLabs(api_key=self.api_key)
+
+        try:
+            video_context = self._build_video_context(client, source)
+            kwargs = {"max_tokens": max(max_tokens, _MIN_MAX_TOKENS)}
+            if temperature is not None:
+                kwargs["temperature"] = temperature
+            response = client.analyze(
+                model_name=model,
+                video=video_context,
+                prompt=text,
+                **kwargs,
+            )
+        except Exception as e:
+            raise RuntimeError(f"TwelveLabs Pegasus error: {e}")
+
+        return str(getattr(response, "data", "") or "").strip()
+
+    def _build_video_context(self, client: "TwelveLabs", source: str):
+        """Build a Pegasus video context from a URL or a local file."""
+        if source.startswith("http://") or source.startswith("https://"):
+            return VideoContext_Url(url=source)
+
+        # Local file: must be uploaded as an asset (no bare video_id support).
+        size = os.path.getsize(source)
+        if size > DIRECT_UPLOAD_MAX_BYTES:
+            raise ValueError(
+                f"Video {os.path.basename(source)} is {size / 1024 / 1024:.0f}MB, "
+                f"over the {DIRECT_UPLOAD_MAX_BYTES // 1024 // 1024}MB direct-upload "
+                "limit. Provide a public URL for larger footage."
+            )
+
+        with open(source, "rb") as fh:
+            asset = client.assets.create(method="direct", file=fh)
+
+        asset_id = self._wait_for_asset(client, asset)
+        return VideoContext_AssetId(asset_id=asset_id)
+
+    def _wait_for_asset(self, client: "TwelveLabs", asset) -> str:
+        """Poll an uploaded asset until it is ready for analysis."""
+        asset_id = asset.id
+        status = (asset.status or "").lower()
+        deadline = time.time() + _ASSET_READY_TIMEOUT_SEC
+        while status not in ("ready", "completed", "") and time.time() < deadline:
+            if status in ("failed", "error"):
+                raise RuntimeError(f"TwelveLabs asset upload failed: {asset_id}")
+            time.sleep(_ASSET_POLL_INTERVAL_SEC)
+            asset = client.assets.retrieve(asset_id)
+            status = (asset.status or "").lower()
+        return asset_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "moviepy==1.0.3",
     "playwright>=1.58.0",
     "dashscope>=1.23.0",
+    "twelvelabs>=1.2.8",
     "requests>=2.32.0",
     "pyjwt>=2.10.0",
     "numpy>=1.26.0",


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## 中文摘要

本 PR 新增 **TwelveLabs Pegasus** 作为可选的视频素材分析（VLM）后端，与现有的 DashScope/Qwen 并列。Pegasus 是视频原生理解模型，会理解整段视频（运动、场景切换、动作），而非仅采样若干帧，因此非常适合在生成脚本/分镜前理解用户上传的视频素材。

- 完全**可选、不改变默认行为**：未配置 `twelvelabs` API Key 时行为不变。
- 在「素材分析服务」中作为**仅视频**选项出现（Pegasus 不分析图片）。
- 已对 TwelveLabs 真实 API 做了端到端验证（上传 → 资产就绪轮询 → 分析返回文本），并附带单元测试。

可在 https://twelvelabs.io 免费获取 API Key（提供慷慨的免费额度）。

## What this adds

This PR adds **TwelveLabs Pegasus** as an opt-in video asset-analysis (VLM) provider, alongside the existing DashScope/Qwen provider used by `APIAssetAnalysisService`. Pegasus is a video-native understanding model — it reasons over the whole clip (motion, scene changes, on-screen action) rather than a handful of sampled frames — which makes it a strong fit for understanding uploaded footage before script/storyboard generation.

Concretely:
- `PegasusClient` (`vlm_twelvelabs.py`) mirrors the existing `vlm_dashscope.py` client style. It accepts public URLs and local files (local files are uploaded as a TwelveLabs asset; direct upload is capped at 200MB, larger footage should be passed as a public URL).
- The unified `VLM` client routes `pegasus*` models to TwelveLabs and everything else to DashScope. Pegasus is **video-only** and cleanly rejects image input.
- Wired into `APIAssetAnalysisService.list_models()` (exposed as a video-only option) and the `api_providers` config schema + `config.example.yaml`.
- Added `twelvelabs>=1.2.8` (the official SDK) to dependencies.

## Why it helps this project

Pixelle-Video already supports swapping analysis backends (RunningHub / self-host ComfyUI / direct API VLM). For users who feed real video clips into the asset-based pipeline, a video-native model produces noticeably more grounded descriptions than frame-sampling VLMs, which improves downstream script and storyboard quality. It slots into the existing provider/registry pattern, so it's just one more option in the dropdown.

## Opt-in & non-breaking

If no `twelvelabs` API key is configured, nothing changes — the provider is simply not listed. No defaults are altered.

## How it was tested

- **Live-verified against the real TwelveLabs API** in this PR's development: the full `PegasusClient` path (local file upload → asset-ready poll → `analyze`) returns a correct text description; I also confirmed the API contract directly.
- Unit tests cover provider routing, the configured-only listing, the video-only image-rejection guard, and the "requires video" guard (no network). A live test (skipped unless `TWELVELABS_API_KEY` is set) exercises the real upload→analyze path. Note: the repo's `.gitignore` excludes `test_*.py`, so the test file is not committed — happy to add it under a different path/name if you'd like it tracked.
- `ruff check` passes clean on the new files.

## Possible follow-up

TwelveLabs also offers **Marengo** multimodal embeddings (512-dim), which would enable footage *retrieval/selection* (ranking uploaded clips against a query) — a natural next step if you'd like a selection backend; happy to follow up in a separate PR.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.

---

Note: TwelveLabs employee contribution. If AIDC-AI requires a CLA or maintainer sign-off for external contributions, just let me know and I'll complete it.
