### PR TITLE
Add selectable OpenAI Responses API image generation mode

### DIFF
--- a/pixelle_video/config/schema.py
+++ b/pixelle_video/config/schema.py
@@ -37,6 +37,7 @@ class APIKeyProviderConfig(BaseModel):
     api_key: str = Field(default="", description="Provider API Key")
     base_url: str = Field(default="", description="Provider API Base URL")
     use_proxy: bool = Field(default=False, description="Route provider requests through common local proxy")
+    image_api_mode: str = Field(default="images", description="OpenAI image API mode: 'images' or 'responses'")
 
 
 class AccessSecretProviderConfig(BaseModel):

--- a/pixelle_video/services/api_media.py
+++ b/pixelle_video/services/api_media.py
@@ -676,6 +676,7 @@ class APIProviderMediaService:
             dashscope_local_proxy=local_proxy if cfg["dashscope"].get("use_proxy") else None,
             gpt_api_key=cfg["openai"].get("api_key") or None,
             gpt_base_url=cfg["openai"].get("base_url") or None,
+            gpt_image_api_mode=cfg["openai"].get("image_api_mode") or None,
             local_proxy=local_proxy if cfg["openai"].get("use_proxy") else None,
             ark_api_key=cfg["ark"].get("api_key") or None,
             ark_base_url=cfg["ark"].get("base_url") or None,

--- a/pixelle_video/services/api_services/config.py
+++ b/pixelle_video/services/api_services/config.py
@@ -26,6 +26,7 @@ class _ConfigMeta(type):
             "LOCAL_PROXY": ("common", "local_proxy", ""),
             "OPENAI_API_KEY": ("openai", "api_key", ""),
             "OPENAI_BASE_URL": ("openai", "base_url", ""),
+            "OPENAI_IMAGE_API_MODE": ("openai", "image_api_mode", "images"),
             "DASHSCOPE_API_KEY": ("dashscope", "api_key", ""),
             "DASHSCOPE_BASE_URL": ("dashscope", "base_url", ""),
             "DEEPSEEK_API_KEY": ("deepseek", "api_key", ""),

--- a/pixelle_video/services/api_services/image_client.py
+++ b/pixelle_video/services/api_services/image_client.py
@@ -23,6 +23,7 @@ class ImageClient:
                  dashscope_local_proxy: Optional[str] = None,
                  gpt_api_key: Optional[str] = None,
                  gpt_base_url: Optional[str] = None,
+                 gpt_image_api_mode: Optional[str] = None,
                  local_proxy: Optional[str] = None,
                  ark_api_key: Optional[str] = None,
                  ark_base_url: Optional[str] = None,
@@ -37,6 +38,7 @@ class ImageClient:
 
         self._gpt_api_key = gpt_api_key or Config.OPENAI_API_KEY
         self._gpt_base_url = gpt_base_url or Config.OPENAI_BASE_URL
+        self._gpt_image_api_mode = gpt_image_api_mode or Config.OPENAI_IMAGE_API_MODE
         self._gpt_local_proxy = local_proxy or Config.LOCAL_PROXY
 
         self._ark_api_key = ark_api_key or Config.ARK_API_KEY
@@ -86,6 +88,7 @@ class ImageClient:
             self._gpt_client = ImageGPT(
                 api_key=self._gpt_api_key,
                 base_url=self._gpt_base_url,
+                image_api_mode=self._gpt_image_api_mode,
                 local_proxy=self._gpt_local_proxy,
             )
         return self._gpt_client

--- a/pixelle_video/services/api_services/image_gpt.py
+++ b/pixelle_video/services/api_services/image_gpt.py
@@ -2,7 +2,10 @@ import os
 import time
 import uuid
 import base64
+import re
 import httpx
+from typing import Optional
+
 from openai import OpenAI
 try:
     from .image_processor import ImageProcessor
@@ -20,6 +23,7 @@ class ImageGPT:
     def __init__(self,
                  api_key: str = None,
                  base_url: str = None,
+                 image_api_mode: str = "images",
                  local_proxy: str = None,
                  timeout: float = 300.0):
         """
@@ -30,6 +34,9 @@ class ImageGPT:
         """
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         self.timeout = timeout
+        self.image_api_mode = (image_api_mode or "images").strip().lower()
+        if self.image_api_mode not in {"images", "responses"}:
+            self.image_api_mode = "images"
         
         kwargs = {"api_key": self.api_key, "timeout": self.timeout}
         
@@ -45,6 +52,104 @@ class ImageGPT:
         self.client = OpenAI(**kwargs)
         self.max_attempts = 10
         self.image_processor = ImageProcessor(local_proxy=local_proxy)
+
+    def _save_base64_image(self, b64_value: str, save_dir: Optional[str] = None):
+        """Decode an image base64 string and save it when save_dir is provided."""
+        raw = base64.b64decode(b64_value, validate=False)
+        if raw.startswith(b"\x89PNG"):
+            ext = "png"
+        elif raw.startswith(b"\xff\xd8"):
+            ext = "jpg"
+        elif raw.startswith(b"RIFF"):
+            ext = "webp"
+        else:
+            ext = "png"
+
+        if save_dir:
+            os.makedirs(save_dir, exist_ok=True)
+            file_name = f"gpt_{int(time.time())}_{uuid.uuid4().hex[:6]}.{ext}"
+            file_path = os.path.join(save_dir, file_name)
+            with open(file_path, "wb") as f:
+                f.write(raw)
+            return file_path
+        return b64_value
+
+    def _extract_image_from_obj(self, obj, save_dir: Optional[str] = None):
+        """Find the first image URL or base64 payload in OpenAI-compatible responses."""
+        if isinstance(obj, dict):
+            # Common image-generation output field names used by Responses API and proxies.
+            for key in ("b64_json", "base64", "image_base64", "result"):
+                value = obj.get(key)
+                if isinstance(value, str) and value:
+                    try:
+                        return self._save_base64_image(value, save_dir)
+                    except Exception:
+                        pass
+
+            for key in ("url", "image_url"):
+                value = obj.get(key)
+                if isinstance(value, str) and value.startswith(("http://", "https://")):
+                    if save_dir:
+                        os.makedirs(save_dir, exist_ok=True)
+                        file_name = f"gpt_{int(time.time())}_{uuid.uuid4().hex[:6]}.png"
+                        file_path = os.path.join(save_dir, file_name)
+                        if self.image_processor.download_image(value, file_path):
+                            return file_path
+                    return value
+                if isinstance(value, dict):
+                    found = self._extract_image_from_obj(value, save_dir)
+                    if found:
+                        return found
+
+            for value in obj.values():
+                found = self._extract_image_from_obj(value, save_dir)
+                if found:
+                    return found
+
+        elif isinstance(obj, list):
+            for item in obj:
+                found = self._extract_image_from_obj(item, save_dir)
+                if found:
+                    return found
+
+        elif isinstance(obj, str):
+            if obj.startswith(("http://", "https://")) and (
+                re.search(r"\.(png|jpe?g|webp)(\?|$)", obj, re.I) or "image" in obj.lower()
+            ):
+                return obj
+            if len(obj) > 1000 and re.fullmatch(r"[A-Za-z0-9+/=\n\r]+", obj[:2000]):
+                try:
+                    return self._save_base64_image(obj, save_dir)
+                except Exception:
+                    return None
+        return None
+
+    def _generate_with_responses_api(self, prompt, size="1024x1024", quality="high", model="gpt-image-2",
+                                     save_dir=None, image_urls=None):
+        """Generate an image through /v1/responses image_generation tool."""
+        content = prompt
+        if size:
+            content = f"{content}\n\nImage size/aspect request: {size}. Quality: {quality}."
+
+        input_payload = content
+        if image_urls:
+            parts = [{"type": "input_text", "text": content}]
+            for image_url in image_urls[:6]:
+                parts.append({"type": "input_image", "image_url": self._encode_image_to_base64(image_url)})
+            input_payload = [{"role": "user", "content": parts}]
+
+        response = self.client.responses.create(  # type: ignore[arg-type]
+            model=model,
+            input=input_payload,
+            tools=[{"type": "image_generation"}],
+        )
+
+        # The OpenAI SDK returns pydantic objects; model_dump preserves nested tool output.
+        data = response.model_dump() if hasattr(response, "model_dump") else response
+        result = self._extract_image_from_obj(data, save_dir=save_dir)
+        if not result:
+            raise RuntimeError("未在 Responses API 响应中找到图片 url 或 base64")
+        return result
 
     def _encode_image_to_base64(self, image_path: str) -> str:
         """将本地图片转换为 Base64 编码"""
@@ -88,6 +193,16 @@ class ImageGPT:
 
         while attempts < self.max_attempts:
             try:
+                if self.image_api_mode == "responses":
+                    return self._generate_with_responses_api(
+                        prompt=prompt,
+                        size=size,
+                        quality=quality,
+                        model=model,
+                        save_dir=save_dir,
+                        image_urls=image_urls,
+                    )
+
                 response = self.client.images.generate(
                     model=model,
                     prompt=prompt,

--- a/web/components/settings.py
+++ b/web/components/settings.py
@@ -362,6 +362,22 @@ def render_advanced_settings():
                     placeholder="https://api.openai.com/v1",
                     key="api_media_openai_base_url",
                 )
+                api_openai_image_api_mode = st.selectbox(
+                    "OpenAI 生图接口" if zh else "OpenAI image API",
+                    options=["images", "responses"],
+                    index=1 if (openai_cfg.get("image_api_mode") == "responses") else 0,
+                    format_func=lambda mode: (
+                        "Responses API (/v1/responses，gpt-image-2/部分中转)"
+                        if mode == "responses"
+                        else "Images API (/v1/images/generations，传统生图接口)"
+                    ),
+                    help=(
+                        "如果 gpt-image-2 在中转站通过 /v1/responses 生图，选 Responses API；官方/传统图片接口选 Images API。"
+                        if zh
+                        else "Use Responses API when gpt-image-2 image generation is exposed via /v1/responses; use Images API for traditional /v1/images/generations."
+                    ),
+                    key="api_media_openai_image_api_mode",
+                )
 
                 st.markdown("**DashScope / Wan / HappyHorse**")
                 api_dashscope_use_proxy = st.checkbox(
@@ -462,6 +478,7 @@ def render_advanced_settings():
                         "api_key": api_openai_key or "",
                         "base_url": api_openai_base_url or "",
                         "use_proxy": bool(api_openai_use_proxy),
+                        "image_api_mode": api_openai_image_api_mode,
                     })
                     config_manager.set_api_provider_config("dashscope", {
                         "api_key": api_dashscope_key or "",


### PR DESCRIPTION
## Summary

Adds a selectable OpenAI image generation API mode for direct API media generation:

- `images`: existing `/v1/images/generations` flow
- `responses`: new `/v1/responses` flow using the `image_generation` tool

This helps OpenAI-compatible gateways and newer image models that expose image generation through the Responses API rather than the legacy Images API.

## Changes

- Adds `api_providers.openai.image_api_mode` configuration
- Adds an OpenAI image API selector in the Web UI settings
- Passes the selected mode through `APIProviderMediaService` and `ImageClient`
- Implements Responses API image generation in `ImageGPT`
- Supports extracting generated images from nested response payloads as URL or base64
- Keeps the existing Images API behavior as the default for backward compatibility

## Verification

- Ran Python syntax checks on changed files:
  - `pixelle_video/config/schema.py`
  - `pixelle_video/services/api_media.py`
  - `pixelle_video/services/api_services/config.py`
  - `pixelle_video/services/api_services/image_client.py`
  - `pixelle_video/services/api_services/image_gpt.py`
  - `web/components/settings.py`
- Verified Responses API mode with an OpenAI-compatible gateway and `gpt-image-2`; generation returned a local PNG successfully.
